### PR TITLE
BASHI-76: Fix Commission Rate Group Updates not Persisting.

### DIFF
--- a/src/Mandarin.Services/MandarinServicesExtensions.cs
+++ b/src/Mandarin.Services/MandarinServicesExtensions.cs
@@ -30,7 +30,7 @@ namespace Mandarin.Services
             services.AddLazyCache();
             services.AddMandarinDomainServices();
             services.AddSendGridServices(configuration);
-            services.AddArtistServices(configuration);
+            services.AddArtistServices();
             services.AddSquareServices(configuration);
 
             return services;
@@ -57,7 +57,7 @@ namespace Mandarin.Services
             }
         }
 
-        private static void AddArtistServices(this IServiceCollection services, IConfiguration configuration)
+        private static void AddArtistServices(this IServiceCollection services)
         {
             services.AddScoped<IArtistService, DatabaseArtistService>();
         }

--- a/src/Mandarin/Pages/Admin/Artists/FormStockistDetails.razor
+++ b/src/Mandarin/Pages/Admin/Artists/FormStockistDetails.razor
@@ -230,10 +230,10 @@ else
                 <AddonLabel Class="w-12">%</AddonLabel>
               </Addon>
               <Addon AddonType="AddonType.Body">
-                <Select TValue="CommissionRateGroup" @bind-SelectedValue="@Commission.RateGroup" Disabled="@(!isEditing)">
+                <Select TValue="int?" @bind-SelectedValue="@Commission.RateGroupId" Disabled="@(!isEditing)">
                   @foreach (var group in rateGroups)
                   {
-                    <SelectItem Value="@group">@(group.Rate)%</SelectItem>
+                    <SelectItem TValue="int?" Value="@(group.GroupId)">@(group.Rate)%</SelectItem>
                   }
                 </Select>
               </Addon>
@@ -324,6 +324,7 @@ else
     validations.ClearAll();
     isNew = false;
     isEditing = false;
+    StateHasChanged();
   }
 
   private async Task OnCancelClicked()


### PR DESCRIPTION
Changing the bound value of a navigation property, that is controlled by the a foreign key reference does not update the record to to the new foreign key reference.

Fix is to bind to the underlying foreign key reference, and the selections to use the underlying id but display the interesting value to the user.