### PR TITLE
BASHI-77: Fix Random Build Errors in BuildInformation.

### DIFF
--- a/src/Mandarin/gulpfile.js
+++ b/src/Mandarin/gulpfile.js
@@ -1,4 +1,4 @@
-﻿const gulp = require("gulp");
+const gulp = require("gulp");
 
 async function buildInformation() {
     const simpleGit = require("simple-git");
@@ -24,15 +24,16 @@ async function buildInformation() {
     const rawFromVersionSha = await git.raw(["describe", "--abbrev=0", "--tags", `${toVersionSha}^`]);
     const fromVersionSha = rawFromVersionSha.split("\n")[0];
 
-    const rawCommits = await git.raw(["log", "--pretty=format:%H|%s", `${fromVersionSha}..${toVersionSha}`]);
-    const commits = rawCommits.split("\n")
-        .filter(x => x)
-        .map(x => x.split("|"))
-        .map(x => ({
-            id: x[0],
-            comment: x.splice(1).join("|")
-        }));
-    fancyLog.info(`Found ${commits.length} commits.`);
+    const commits = await git.log({
+        from: fromVersionSha,
+        to: toVersionSha,
+        format: {
+            id: "%H",
+            comment: "%s"
+        }
+    }, x => x);
+
+    fancyLog.info(`Found ${commits.all.length} commits.`);
 
     const info = {
         buildEnvironment: "GitHub Actions",
@@ -42,7 +43,7 @@ async function buildInformation() {
         vcsType: "Git",
         vcsRoot: packageJson.repository.url,
         vcsCommitNumber: toVersionSha,
-        commits: commits
+        commits: commits.all
     };
     fancyLog.info(info);
 

--- a/src/Mandarin/gulpfile.js
+++ b/src/Mandarin/gulpfile.js
@@ -1,4 +1,4 @@
-const gulp = require("gulp");
+﻿const gulp = require("gulp");
 
 async function buildInformation() {
     const simpleGit = require("simple-git");
@@ -21,7 +21,7 @@ async function buildInformation() {
         return;
     }
 
-    const rawFromVersionSha = await git.raw(["describe", "--abbrev=0", "--tags", `${toVersionSha}^`]);
+    const rawFromVersionSha = await git.raw(["rev-list", "--tags", "--max-count=1"]);
     const fromVersionSha = rawFromVersionSha.split("\n")[0];
 
     const commits = await git.log({


### PR DESCRIPTION
Since update to `simple-git` to use git.log, GitHub Actions has encountered build errors like the following stacktrace:

```
[21:22:30] Using gulpfile ~/work/Mandarin/Mandarin/src/Mandarin/gulpfile.js
[21:22:30] Starting 'buildInformation'...
[21:22:30] 'buildInformation' errored after 44 ms
[21:22:30] Error: fatal: Not a valid object name e94162bd93cfbccb6be742c1220d29411817e664^

    at GitExecutorChain.onFatalException (/home/runner/work/Mandarin/Mandarin/src/Mandarin/node_modules/simple-git/src/lib/runners/git-executor-chain.js:60:87)
    at GitExecutorChain.<anonymous> (/home/runner/work/Mandarin/Mandarin/src/Mandarin/node_modules/simple-git/src/lib/runners/git-executor-chain.js:51:28)
    at Generator.throw (<anonymous>)
    at rejected (/home/runner/work/Mandarin/Mandarin/src/Mandarin/node_modules/simple-git/src/lib/runners/git-executor-chain.js:6:65)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

Reverting to see if the situation improves. Alternatively can look at new versions of `simple-git`.