### PR TITLE
BASHI-115: Fix connection limit breaking Record of Sales.

### DIFF
--- a/src/Mandarin/appsettings.json
+++ b/src/Mandarin/appsettings.json
@@ -5,7 +5,7 @@
     "Audience": ""
   },
   "ConnectionStrings": {
-    "MandarinConnection": "Host=localhost;Database=postgres;Username=postgres;Password=password"
+    "MandarinConnection": "Host=localhost;Database=postgres;Username=postgres;Password=password;Maximum Pool Size=5"
   },
   "ElasticApm": {
     "CaptureBody": true,

--- a/tests/Mandarin.Tests/Helpers/MandarinApplicationFactory.cs
+++ b/tests/Mandarin.Tests/Helpers/MandarinApplicationFactory.cs
@@ -45,7 +45,7 @@ namespace Mandarin.Tests.Helpers
                 { "Auth0:Domain", "localhost" },
                 { "Auth0:ClientId", "SuperSecretId" },
                 { "Auth0:ClientSecret", "SuperSecretValue" },
-                { "ConnectionStrings:MandarinConnection", "Host=localhost;Port=5555;Database=postgres;Username=postgres;Password=password;Include Error Detail=true" },
+                { "ConnectionStrings:MandarinConnection", "Host=localhost;Port=5555;Database=postgres;Username=postgres;Password=password;Maximum Pool Size=5;Include Error Detail=true" },
                 { "Mandarin:FixedCommissionAmountFilePath", WellKnownTestData.Commissions.FixedCommissions },
                 { "SendGrid:ServiceEmail", "ServiceEmail@example.com" },
                 { "SendGrid:RealContactEmail", "RealContactEmail@example.com" },


### PR DESCRIPTION
Npgsql's connection pooling strategy is a bit bizarre here... it wants to fill the pool entirely before it begins reusing existing connections.
The default pool size is 100, which happens to coincide with Postgres's default maximum concurrent connection size.
As there are other applications connected to the Postgres instance, Mandarin can't get the full set of 100 connections it wants, and so blows up attempting to fill the pool.

Fix therefore is to bring the maximum pool size down from 100 to 5 - which is reasonable for the load produced by Mandarin.