### PR TITLE
BASHI-118: Allow FramePrices to Differ by Transaction Date.

### DIFF
--- a/src/Mandarin.Client.Services/Inventory/MandarinGrpcFramePricesService.cs
+++ b/src/Mandarin.Client.Services/Inventory/MandarinGrpcFramePricesService.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
+using Google.Protobuf.WellKnownTypes;
 using Mandarin.Api.Inventory;
 using Mandarin.Inventory;
 using static Mandarin.Api.Inventory.FramePrices;
@@ -34,9 +36,9 @@ namespace Mandarin.Client.Services.Inventory
         }
 
         /// <inheritdoc/>
-        public async Task<FramePrice> GetFramePriceAsync(string productCode)
+        public async Task<FramePrice> GetFramePriceAsync(string productCode, DateTime transactionTime)
         {
-            var request = new GetFramePriceRequest { ProductCode = productCode };
+            var request = new GetFramePriceRequest { ProductCode = productCode, TransactionTime = this.mapper.Map<Timestamp>(transactionTime) };
             var response = await this.framePricesClient.GetFramePriceAsync(request);
             return this.mapper.Map<FramePrice>(response.FramePrice);
         }

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesEditViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesEditViewModel.cs
@@ -91,6 +91,7 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
             var existingFramePrice = await this.framePricesService.GetFramePriceAsync(productCode);
             this.Product = await this.productService.GetProductByProductCodeAsync(productCode);
             this.FrameAmount = existingFramePrice.Amount;
+            this.CreatedAt = existingFramePrice.CreatedAt;
         }
 
         private async Task OnSave()

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesEditViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesEditViewModel.cs
@@ -88,10 +88,13 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
 
         private async Task OnLoadData(string productCode)
         {
-            var existingFramePrice = await this.framePricesService.GetFramePriceAsync(productCode);
+            var existingFramePrice = await this.framePricesService.GetFramePriceAsync(productCode, DateTime.Now);
             this.Product = await this.productService.GetProductByProductCodeAsync(productCode);
             this.FrameAmount = existingFramePrice.Amount;
             this.CreatedAt = existingFramePrice.CreatedAt;
+            this.WhenAnyValue(vm => vm.FrameAmount)
+                .Select(amount => amount == existingFramePrice.Amount ? existingFramePrice.CreatedAt : DateTime.Now)
+                .Subscribe(date => this.CreatedAt = date);
         }
 
         private async Task OnSave()

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesNewViewModel.cs
@@ -24,6 +24,7 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
         private readonly ObservableAsPropertyHelper<decimal?> stockistAmount;
         private Product selectedProduct;
         private decimal? frameAmount;
+        private DateTime? createdAt;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FramePricesNewViewModel"/> class.
@@ -41,8 +42,10 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
             this.Products = new ReadOnlyObservableCollection<Product>(products);
 
             this.LoadData = ReactiveCommand.CreateFromObservable(this.OnLoadData);
-            this.Save = ReactiveCommand.CreateFromTask(this.OnSave, this.WhenAnyValue(vm => vm.SelectedProduct, vm => vm.FrameAmount)
-                                                                        .Select(tuple => tuple.Item1 != null && tuple.Item2.HasValue));
+            this.Save = ReactiveCommand.CreateFromTask(this.OnSave, this.WhenAnyValue(vm => vm.SelectedProduct,
+                                                                                      vm => vm.FrameAmount,
+                                                                                      vm => vm.CreatedAt,
+                                                                                      (p, f, c) => p != null && f.HasValue && c.HasValue));
             this.Cancel = ReactiveCommand.Create(this.OnCancel);
 
             this.productAmount = this.WhenAnyValue(vm => vm.SelectedProduct).WhereNotNull().Select(p => p.UnitPrice).ToProperty(this, x => x.ProductAmount);
@@ -81,6 +84,13 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
         }
 
         /// <inheritdoc/>
+        public DateTime? CreatedAt
+        {
+            get => this.createdAt;
+            set => this.RaiseAndSetIfChanged(ref this.createdAt, value);
+        }
+
+        /// <inheritdoc/>
         public decimal? ProductAmount => this.productAmount.Value;
 
         /// <inheritdoc/>
@@ -93,7 +103,17 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
 
         private async Task OnSave()
         {
-            var framePrice = new FramePrice(this.SelectedProduct.ProductCode, this.FrameAmount.Value);
+            if (!this.FrameAmount.HasValue || !this.CreatedAt.HasValue)
+            {
+                return;
+            }
+
+            var framePrice = new FramePrice
+            {
+                ProductCode = this.SelectedProduct.ProductCode,
+                Amount = this.FrameAmount.Value,
+                CreatedAt = this.CreatedAt.Value,
+            };
             await this.framePricesService.SaveFramePriceAsync(framePrice);
 
             this.navigationManager.NavigateTo($"/inventory/frame-prices/edit/{this.selectedProduct.ProductCode}");

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesNewViewModel.cs
@@ -5,6 +5,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
+using Blazorise.Utils;
 using Mandarin.Client.ViewModels.Extensions;
 using Mandarin.Inventory;
 using Microsoft.AspNetCore.Components;
@@ -40,6 +41,7 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
 
             var products = new ObservableCollection<Product>();
             this.Products = new ReadOnlyObservableCollection<Product>(products);
+            this.CreatedAt = DateTime.Now;
 
             this.LoadData = ReactiveCommand.CreateFromObservable(this.OnLoadData);
             this.Save = ReactiveCommand.CreateFromTask(this.OnSave, this.WhenAnyValue(vm => vm.SelectedProduct,

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePricesEditViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePricesEditViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive;
+﻿using System;
+using System.Reactive;
 using Mandarin.Inventory;
 using ReactiveUI;
 
@@ -38,6 +39,11 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
         /// Gets or sets the frame price to be associated to the selected product.
         /// </summary>
         decimal? FrameAmount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp at which the frame price should be considered as active.
+        /// </summary>
+        DateTime? CreatedAt { get; set; }
 
         /// <summary>
         /// Gets the total cost of the product.

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePricesNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePricesNewViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reactive;
 using Mandarin.Inventory;
@@ -45,6 +46,11 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
         /// Gets or sets the frame price to be associated to the selected product.
         /// </summary>
         decimal? FrameAmount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp at which the frame price should be considered as active.
+        /// </summary>
+        DateTime? CreatedAt { get; set; }
 
         /// <summary>
         /// Gets the total cost of the product.

--- a/src/Mandarin.Client/Pages/Inventory/FramePrices/FramePricesEdit.razor
+++ b/src/Mandarin.Client/Pages/Inventory/FramePrices/FramePricesEdit.razor
@@ -25,6 +25,14 @@
         </Field>
       </Validation>
       <Validation>
+        <Field>
+          <FieldLabel>Active From</FieldLabel>
+          <DateEdit TItem="DateTime?" @bind-Date="@(ViewModel!.CreatedAt)">
+            <Feedback><ValidationError/></Feedback>
+          </DateEdit>
+        </Field>
+      </Validation>
+      <Validation>
         <Fields>
           <Field ColumnSize="ColumnSize.Is4">
             <FieldLabel>Frame Price</FieldLabel>

--- a/src/Mandarin.Client/Pages/Inventory/FramePrices/FramePricesNew.razor
+++ b/src/Mandarin.Client/Pages/Inventory/FramePrices/FramePricesNew.razor
@@ -29,6 +29,14 @@
         </Field>
       </Validation>
       <Validation>
+        <Field>
+          <FieldLabel>Active From</FieldLabel>
+          <DateEdit TItem="DateTime?" @bind-Date="@(ViewModel!.CreatedAt)">
+            <Feedback><ValidationError/></Feedback>
+          </DateEdit>
+        </Field>
+      </Validation>
+      <Validation>
         <Fields>
           <Field ColumnSize="ColumnSize.Is4">
             <FieldLabel>Frame Price</FieldLabel>

--- a/src/Mandarin.Database/Inventory/FramePriceRecord.cs
+++ b/src/Mandarin.Database/Inventory/FramePriceRecord.cs
@@ -15,6 +15,6 @@ namespace Mandarin.Database.Inventory
         public string product_code { get; init; }
         public decimal amount { get; init; }
         public DateTime created_at { get; init; }
-        public DateTime active_until { get; init; }
+        public DateTime? active_until { get; init; }
     }
 }

--- a/src/Mandarin.Database/Inventory/FramePriceRecord.cs
+++ b/src/Mandarin.Database/Inventory/FramePriceRecord.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Mandarin.Database.Inventory
 {
@@ -12,6 +13,8 @@ namespace Mandarin.Database.Inventory
     internal sealed record FramePriceRecord
     {
         public string product_code { get; init; }
-        public double amount { get; init; }
+        public decimal amount { get; init; }
+        public DateTime created_at { get; init; }
+        public DateTime active_until { get; init; }
     }
 }

--- a/src/Mandarin.Database/Inventory/FramePriceRepository.cs
+++ b/src/Mandarin.Database/Inventory/FramePriceRepository.cs
@@ -23,6 +23,9 @@ namespace Mandarin.Database.Inventory
             FROM inventory.frame_price
             ORDER BY product_code";
 
+        private const string UpsertFramePriceSql = @"
+            CALL inventory.sp_frame_price_upsert(@product_code, @amount, @created_at)";
+
         private const string DeleteFramePriceSql = @"
             DELETE FROM inventory.frame_price
             WHERE product_code = @product_code";
@@ -80,12 +83,7 @@ namespace Mandarin.Database.Inventory
         /// <inheritdoc/>
         protected override async Task<FramePriceRecord> UpsertRecordAsync(IDbConnection db, FramePriceRecord record)
         {
-            var p = new DynamicParameters();
-            p.Add("product_code", record.product_code, DbType.String);
-            p.Add("amount", record.amount, DbType.VarNumeric);
-            p.Add("created_at", record.created_at, DbType.DateTime);
-
-            await db.ExecuteAsync("sp_frame_price_upsert", p, commandType: CommandType.StoredProcedure);
+            await db.ExecuteAsync(FramePriceRepository.UpsertFramePriceSql, record);
             return record;
         }
     }

--- a/src/Mandarin.Database/Inventory/FramePriceRepository.cs
+++ b/src/Mandarin.Database/Inventory/FramePriceRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -16,6 +17,8 @@ namespace Mandarin.Database.Inventory
             SELECT *
             FROM inventory.frame_price
             WHERE product_code = @product_code
+              AND created_at <= @created_at
+              AND (active_until IS NULL OR active_until > @created_at)
             LIMIT 1";
 
         private const string GetAllFramePricesSql = @"
@@ -42,12 +45,12 @@ namespace Mandarin.Database.Inventory
         }
 
         /// <inheritdoc/>
-        public Task<FramePrice> GetByProductCodeAsync(string productCode)
+        public Task<FramePrice> GetByProductCodeAsync(string productCode, DateTime activeSince)
         {
             return this.Get(productCode,
                             db =>
                             {
-                                var parameters = new { product_code = productCode };
+                                var parameters = new { product_code = productCode, created_at = activeSince };
                                 return db.QueryFirstOrDefaultAsync<FramePriceRecord>(FramePriceRepository.GetFramePriceByProductCodeSql, parameters);
                             });
         }

--- a/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
+++ b/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
@@ -25,7 +25,7 @@ CREATE OR REPLACE PROCEDURE inventory.sp_frame_price_upsert(
 AS
 $$
 DECLARE
-begin
+BEGIN
     UPDATE inventory.frame_price
     SET active_until = $3
     WHERE product_code = $1
@@ -33,5 +33,5 @@ begin
 
     INSERT INTO inventory.frame_price (product_code, amount, created_at)
     VALUES ($1, $2, $3);
-end;
+END
 $$

--- a/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
+++ b/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
@@ -1,0 +1,13 @@
+﻿-- BASHI-118: Allow Frame Prices to Differ by Transaction Date
+ALTER TABLE inventory.frame_price
+    ADD COLUMN created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3),
+    ADD COLUMN active_until TIMESTAMP(3) NULL;
+
+-- noinspection SqlWithoutWhere
+UPDATE inventory.frame_price
+    SET created_at = '2019-06-01';
+
+ALTER TABLE inventory.frame_price
+    ALTER COLUMN created_at SET NOT NULL,
+    DROP CONSTRAINT fixed_commission_amount_pkey,
+    ADD PRIMARY KEY (product_code, created_at);

--- a/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
+++ b/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
@@ -1,13 +1,37 @@
 ﻿-- BASHI-118: Allow Frame Prices to Differ by Transaction Date
-ALTER TABLE inventory.frame_price
-    ADD COLUMN created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3),
-    ADD COLUMN active_until TIMESTAMP(3) NULL;
+CREATE TABLE inventory.new_frame_price
+(
+    frame_price_id SERIAL PRIMARY KEY,
+    product_code   VARCHAR(12)   NOT NULL,
+    amount         NUMERIC(6, 2) NOT NULL,
+    created_at     TIMESTAMP(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    active_until   TIMESTAMP(3)  NULL
+);
 
--- noinspection SqlWithoutWhere
-UPDATE inventory.frame_price
-    SET created_at = '2019-06-01';
+INSERT INTO inventory.new_frame_price (product_code, amount, created_at)
+SELECT f.product_code, f.amount, '2019-06-01'
+FROM inventory.frame_price f;
 
-ALTER TABLE inventory.frame_price
-    ALTER COLUMN created_at SET NOT NULL,
-    DROP CONSTRAINT fixed_commission_amount_pkey,
-    ADD PRIMARY KEY (product_code, created_at);
+DROP TABLE inventory.frame_price;
+ALTER TABLE inventory.new_frame_price
+    RENAME TO frame_price;
+
+
+CREATE OR REPLACE PROCEDURE sp_frame_price_upsert(
+    product_code varchar(12),
+    amount NUMERIC(6, 2),
+    created_at TIMESTAMP(3))
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+begin
+    UPDATE inventory.frame_price
+    SET active_until = $3
+    WHERE product_code = $1
+      AND active_until IS NULL;
+
+    INSERT INTO inventory.frame_price (product_code, amount, created_at)
+    VALUES ($1, $2, $3);
+end;
+$$

--- a/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
+++ b/src/Mandarin.Database/Migrations/007-AddFramePriceTimestamp.sql
@@ -17,10 +17,10 @@ ALTER TABLE inventory.new_frame_price
     RENAME TO frame_price;
 
 
-CREATE OR REPLACE PROCEDURE sp_frame_price_upsert(
-    product_code varchar(12),
-    amount NUMERIC(6, 2),
-    created_at TIMESTAMP(3))
+CREATE OR REPLACE PROCEDURE inventory.sp_frame_price_upsert(
+    _product_code TEXT,
+    _amount NUMERIC,
+    _created_at TIMESTAMP)
     LANGUAGE plpgsql
 AS
 $$

--- a/src/Mandarin.Interfaces.Grpc/Protos/FramePrices.proto
+++ b/src/Mandarin.Interfaces.Grpc/Protos/FramePrices.proto
@@ -25,6 +25,7 @@ message GetAllFramePricesResponse {
 
 message GetFramePriceRequest {
   string productCode = 1;
+  google.protobuf.Timestamp transactionTime = 4;
 }
 
 message GetFramePriceResponse {

--- a/src/Mandarin.Interfaces.Grpc/Protos/FramePrices.proto
+++ b/src/Mandarin.Interfaces.Grpc/Protos/FramePrices.proto
@@ -1,5 +1,6 @@
 ﻿syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 option csharp_namespace = "Mandarin.Api.Inventory";
@@ -48,4 +49,6 @@ message DeleteFramePriceResponse {
 message FramePrice {
   string productCode = 1;
   google.protobuf.DoubleValue amount = 2;
+  google.protobuf.Timestamp createdAt = 3;
+  google.protobuf.Timestamp activeUntil = 4;
 }

--- a/src/Mandarin.Interfaces/Inventory/FramePrice.cs
+++ b/src/Mandarin.Interfaces/Inventory/FramePrice.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Mandarin.Inventory
 {
@@ -12,10 +13,14 @@ namespace Mandarin.Inventory
         /// </summary>
         /// <param name="productCode">Product's unique item code.</param>
         /// <param name="amount">Monetary amount to be considered purely as commission.</param>
-        public FramePrice(string productCode, decimal amount)
+        /// <param name="createdAt">The DateTime when the frame price was created.</param>
+        /// <param name="activeUntil">The time up til which the frame price is active.</param>
+        public FramePrice(string productCode, decimal amount, DateTime? createdAt = null, DateTime? activeUntil = null)
         {
             this.ProductCode = productCode;
             this.Amount = amount;
+            this.CreatedAt = createdAt;
+            this.ActiveUntil = activeUntil;
         }
 
         /// <summary>
@@ -29,5 +34,15 @@ namespace Mandarin.Inventory
         /// </summary>
         [JsonProperty("amount")]
         public decimal Amount { get; }
+
+        /// <summary>
+        /// Gets the time the entry was created.
+        /// </summary>
+        public DateTime? CreatedAt { get; }
+
+        /// <summary>
+        /// Gets the last time that the frame price is active til, or null.
+        /// </summary>
+        public DateTime? ActiveUntil { get; }
     }
 }

--- a/src/Mandarin.Interfaces/Inventory/FramePrice.cs
+++ b/src/Mandarin.Interfaces/Inventory/FramePrice.cs
@@ -6,43 +6,28 @@ namespace Mandarin.Inventory
     /// <summary>
     /// Represents a partial amount on a sale of a framed product, where the frame price is considered as separate to the Artist's commission purposes.
     /// </summary>
-    public class FramePrice
+    public record FramePrice
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FramePrice"/> class.
-        /// </summary>
-        /// <param name="productCode">Product's unique item code.</param>
-        /// <param name="amount">Monetary amount to be considered purely as commission.</param>
-        /// <param name="createdAt">The DateTime when the frame price was created.</param>
-        /// <param name="activeUntil">The time up til which the frame price is active.</param>
-        public FramePrice(string productCode, decimal amount, DateTime? createdAt = null, DateTime? activeUntil = null)
-        {
-            this.ProductCode = productCode;
-            this.Amount = amount;
-            this.CreatedAt = createdAt;
-            this.ActiveUntil = activeUntil;
-        }
-
         /// <summary>
         /// Gets the product's unique item code.
         /// </summary>
         [JsonProperty("product_code")]
-        public string ProductCode { get; }
+        public string ProductCode { get; init; }
 
         /// <summary>
         /// Gets the product's frame price.
         /// </summary>
         [JsonProperty("amount")]
-        public decimal Amount { get; }
+        public decimal Amount { get; init; }
 
         /// <summary>
         /// Gets the time the entry was created.
         /// </summary>
-        public DateTime? CreatedAt { get; }
+        public DateTime CreatedAt { get; init; }
 
         /// <summary>
         /// Gets the last time that the frame price is active til, or null.
         /// </summary>
-        public DateTime? ActiveUntil { get; }
+        public DateTime? ActiveUntil { get; init; }
     }
 }

--- a/src/Mandarin.Interfaces/Inventory/IFramePriceRepository.cs
+++ b/src/Mandarin.Interfaces/Inventory/IFramePriceRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Mandarin.Inventory
@@ -12,8 +13,9 @@ namespace Mandarin.Inventory
         /// Gets the <see cref="FramePrice"/> corresponding to the given product code.
         /// </summary>
         /// <param name="productCode">The product code to search for.</param>
+        /// <param name="activeSince">The timestamp at which the frame price must be active at.</param>
         /// <returns>A <see cref="Task"/> containing the <see cref="FramePrice"/> for the given product code.</returns>
-        Task<FramePrice> GetByProductCodeAsync(string productCode);
+        Task<FramePrice> GetByProductCodeAsync(string productCode, DateTime activeSince);
 
         /// <summary>
         /// Gets the list of all <see cref="FramePrice"/>.

--- a/src/Mandarin.Interfaces/Inventory/IFramePricesService.cs
+++ b/src/Mandarin.Interfaces/Inventory/IFramePricesService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Mandarin.Inventory
@@ -19,8 +20,9 @@ namespace Mandarin.Inventory
         /// If a frame price does not exist, then the result will be null.
         /// </summary>
         /// <param name="productCode">The product code of the product to search for a frame price.</param>
+        /// <param name="transactionTime">The timestamp at which the transaction occurred.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous retrieval of the frame price.</returns>
-        Task<FramePrice> GetFramePriceAsync(string productCode);
+        Task<FramePrice> GetFramePriceAsync(string productCode, DateTime transactionTime);
 
         /// <summary>
         /// Saves all changes made to the <see cref="FramePrice"/>. Will automatically detect if it is a new <see cref="FramePrice"/>

--- a/src/Mandarin.Services/Inventory/FramePricesService.cs
+++ b/src/Mandarin.Services/Inventory/FramePricesService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Mandarin.Inventory;
 using Mandarin.Services.Transactions;
@@ -31,10 +32,10 @@ namespace Mandarin.Services.Inventory
         }
 
         /// <inheritdoc/>
-        public Task<FramePrice> GetFramePriceAsync(string productCode)
+        public Task<FramePrice> GetFramePriceAsync(string productCode, DateTime transactionTime)
         {
-            this.logger.LogDebug("Fetching frame price for '{ProductCode}'.", productCode);
-            return this.framePriceRepository.GetByProductCodeAsync(productCode);
+            this.logger.LogDebug("Fetching frame price for '{ProductCode}' @ '{TransactionTime}'.", productCode, transactionTime);
+            return this.framePriceRepository.GetByProductCodeAsync(productCode, transactionTime);
         }
 
         /// <inheritdoc />

--- a/src/Mandarin.Services/Transactions/TransactionMapper.cs
+++ b/src/Mandarin.Services/Transactions/TransactionMapper.cs
@@ -65,7 +65,7 @@ namespace Mandarin.Services.Transactions
                        .ToObservable()
                        .SelectMany(product =>
                        {
-                           return this.framePricesService.GetFramePriceAsync(product.ProductCode)
+                           return this.framePricesService.GetFramePriceAsync(product.ProductCode, orderDate)
                                       .ToObservable()
                                       .SelectMany(framePrice => Create(product, framePrice));
                        });

--- a/src/Mandarin/Grpc/FramePricesGrpcService.cs
+++ b/src/Mandarin/Grpc/FramePricesGrpcService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
 using Grpc.Core;
@@ -41,7 +42,8 @@ namespace Mandarin.Grpc
         /// <inheritdoc/>
         public override async Task<GetFramePriceResponse> GetFramePrice(GetFramePriceRequest request, ServerCallContext context)
         {
-            var framePrice = await this.framePricesService.GetFramePriceAsync(request.ProductCode);
+            var transactionTime = this.mapper.Map<DateTime>(request.TransactionTime);
+            var framePrice = await this.framePricesService.GetFramePriceAsync(request.ProductCode, transactionTime);
             return new GetFramePriceResponse
             {
                 FramePrice = this.mapper.Map<FramePrice>(framePrice),

--- a/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Mandarin.Inventory;
 using Mandarin.Tests.Helpers;
@@ -27,11 +28,28 @@ namespace Mandarin.Client.Services.Tests.Inventory
         [Fact]
         public async Task ShouldBeAbleToAddAndRoundTripANewFramePrice()
         {
-            var framePrice = new FramePrice("OM19-001", 15.00M);
+            var framePrice = new FramePrice("OM19-001", 15.00M, new DateTime(2021, 06, 30));
             await this.Subject.SaveFramePriceAsync(framePrice);
 
             var newFramePrice = await this.Subject.GetFramePriceAsync("OM19-001");
             newFramePrice.Should().BeEquivalentTo(framePrice);
+        }
+
+        [Fact]
+        public async Task ShouldBeAbleToUpdateAndRoundTripAFramePrice()
+        {
+            var existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F");
+            existingFramePrice.Amount.Should().Be(50.00M);
+            existingFramePrice.CreatedAt.Should().Be(new DateTime(2019, 06, 01));
+            existingFramePrice.ActiveUntil.Should().BeNull();
+
+            var newFramePrice = new FramePrice("KT20-001F", 25.00M, new DateTime(2021, 06, 30));
+            await this.Subject.SaveFramePriceAsync(newFramePrice);
+
+            existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F");
+            existingFramePrice.Amount.Should().Be(25.00M);
+            existingFramePrice.CreatedAt.Should().Be(new DateTime(2021, 06, 30));
+            existingFramePrice.ActiveUntil.Should().BeNull();
         }
 
         [Fact]

--- a/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Grpc.Core;
 using Mandarin.Inventory;
 using Mandarin.Tests.Helpers;
 using Xunit;

--- a/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
@@ -37,30 +37,34 @@ namespace Mandarin.Client.Services.Tests.Inventory
             };
             await this.Subject.SaveFramePriceAsync(framePrice);
 
-            var newFramePrice = await this.Subject.GetFramePriceAsync("OM19-001");
+            var newFramePrice = await this.Subject.GetFramePriceAsync("OM19-001", DateTime.Now);
             newFramePrice.Should().BeEquivalentTo(framePrice);
         }
 
         [Fact]
         public async Task ShouldBeAbleToUpdateAndRoundTripAFramePrice()
         {
-            var existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F");
-            existingFramePrice.Amount.Should().Be(50.00M);
-            existingFramePrice.CreatedAt.Should().Be(new DateTime(2019, 06, 01));
-            existingFramePrice.ActiveUntil.Should().BeNull();
+            var expected = new FramePrice
+            {
+                ProductCode = "KT20-001F",
+                Amount = 50.00M,
+                CreatedAt = new DateTime(2019, 06, 01),
+                ActiveUntil = null,
+            };
 
+            (await this.Subject.GetFramePriceAsync("KT20-001F", DateTime.Now)).Should().Be(expected);
+
+            var today = new DateTime(2021, 06, 30);
             var newFramePrice = new FramePrice
             {
                 ProductCode = "KT20-001F",
                 Amount = 25.00M,
-                CreatedAt = new DateTime(2021, 06, 30),
+                CreatedAt = today,
             };
             await this.Subject.SaveFramePriceAsync(newFramePrice);
 
-            existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F");
-            existingFramePrice.Amount.Should().Be(25.00M);
-            existingFramePrice.CreatedAt.Should().Be(new DateTime(2021, 06, 30));
-            existingFramePrice.ActiveUntil.Should().BeNull();
+            (await this.Subject.GetFramePriceAsync("KT20-001F", new DateTime(2021, 05, 15))).Should().Be(expected with { ActiveUntil = today });
+            (await this.Subject.GetFramePriceAsync("KT20-001F", today)).Should().Be(newFramePrice);
         }
 
         [Fact]
@@ -68,9 +72,9 @@ namespace Mandarin.Client.Services.Tests.Inventory
         {
             await this.Subject.DeleteFramePriceAsync("KT20-001F");
 
-            var deletedFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F");
+            var deletedFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F", DateTime.Now);
             deletedFramePrice.Should().BeNull();
-            var existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-002F");
+            var existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-002F", DateTime.Now);
             existingFramePrice.Should().NotBeNull();
         }
     }

--- a/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
@@ -28,7 +28,12 @@ namespace Mandarin.Client.Services.Tests.Inventory
         [Fact]
         public async Task ShouldBeAbleToAddAndRoundTripANewFramePrice()
         {
-            var framePrice = new FramePrice("OM19-001", 15.00M, new DateTime(2021, 06, 30));
+            var framePrice = new FramePrice
+            {
+                ProductCode = "OM19-001",
+                Amount = 15.00M,
+                CreatedAt = new DateTime(2021, 06, 30),
+            };
             await this.Subject.SaveFramePriceAsync(framePrice);
 
             var newFramePrice = await this.Subject.GetFramePriceAsync("OM19-001");
@@ -43,7 +48,12 @@ namespace Mandarin.Client.Services.Tests.Inventory
             existingFramePrice.CreatedAt.Should().Be(new DateTime(2019, 06, 01));
             existingFramePrice.ActiveUntil.Should().BeNull();
 
-            var newFramePrice = new FramePrice("KT20-001F", 25.00M, new DateTime(2021, 06, 30));
+            var newFramePrice = new FramePrice
+            {
+                ProductCode = "KT20-001F",
+                Amount = 25.00M,
+                CreatedAt = new DateTime(2021, 06, 30),
+            };
             await this.Subject.SaveFramePriceAsync(newFramePrice);
 
             existingFramePrice = await this.Subject.GetFramePriceAsync("KT20-001F");

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePriceGridRowViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePriceGridRowViewModelTests.cs
@@ -7,7 +7,12 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
 {
     public class FramePriceGridRowViewModelTests
     {
-        private static readonly FramePrice FramePrice = new("TLM-001", 15.00M);
+        private static readonly FramePrice FramePrice = new()
+        {
+            ProductCode = "TLM-001",
+            Amount = 15.00M,
+        };
+
         private static readonly Product Product = new("SquareId", "TLM-001", "Mandarin", "It's a Mandarin!", 45.00M);
 
         [Fact]

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesEditViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesEditViewModelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reactive.Linq;
+﻿using System;
+using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using AutoFixture;
@@ -29,7 +30,11 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
 
             this.productService.Setup(x => x.GetProductByProductCodeAsync(product.ProductCode)).ReturnsAsync(product);
             this.framePricesService.Setup(x => x.GetFramePriceAsync(product.ProductCode))
-                .ReturnsAsync(new FramePrice(product.ProductCode, commission.Value));
+                .ReturnsAsync(new FramePrice
+                {
+                    ProductCode = product.ProductCode,
+                    Amount = commission.Value,
+                });
         }
 
 
@@ -120,6 +125,26 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
                 canExecute.Should().BeFalse();
             }
 
+            [Theory]
+            [InlineData(1)]
+            [InlineData(2)]
+            public async Task ShouldNotBeAbleToExecuteWhenAnyRequiredPropertiesIsNotSet(int i)
+            {
+                var subject = this.Subject;
+                if (i != 1)
+                {
+                    subject.FrameAmount = this.fixture.Create<decimal>();
+                }
+
+                if (i != 2)
+                {
+                    subject.CreatedAt = this.fixture.Create<DateTime>();
+                }
+
+                var canExecute = await subject.Save.CanExecute.FirstAsync();
+                canExecute.Should().BeFalse();
+            }
+
             [Fact]
             public async Task ShouldBeAbleToExecuteWhenProductAndCommissionAreSet()
             {
@@ -128,6 +153,7 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
                 var subject = this.Subject;
                 await subject.LoadData.Execute(this.product.ProductCode);
                 subject.FrameAmount = this.fixture.Create<decimal>();
+                subject.CreatedAt = this.fixture.Create<DateTime>();
 
                 var canExecute = await subject.Save.CanExecute.FirstAsync();
                 canExecute.Should().BeTrue();
@@ -141,15 +167,19 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
                 var subject = this.Subject;
                 await subject.LoadData.Execute(this.product.ProductCode);
                 subject.FrameAmount = 20.00M;
+                subject.CreatedAt = new DateTime(2021, 06, 30);
 
                 this.framePricesService.Setup(x => x.SaveFramePriceAsync(It.IsAny<FramePrice>()))
                     .Returns(Task.CompletedTask)
                     .Verifiable();
 
                 await subject.Save.Execute();
-                this.framePricesService.Verify(x => x.SaveFramePriceAsync(It.Is<FramePrice>(amount =>
-                                                                                                amount.ProductCode == this.product.ProductCode &&
-                                                                                                amount.Amount == 20.00M)));
+                this.framePricesService.Verify(x => x.SaveFramePriceAsync(new FramePrice
+                {
+                    ProductCode = this.product.ProductCode,
+                    Amount = 20.00M,
+                    CreatedAt = new DateTime(2021, 06, 30),
+                }));
             }
         }
     }

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesIndexViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesIndexViewModelTests.cs
@@ -13,7 +13,12 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
 {
     public class FramePricesIndexViewModelTests
     {
-        private static readonly FramePrice FramePrice = new("TLM-001", 15.00M);
+        private static readonly FramePrice FramePrice = new()
+        {
+            ProductCode = "TLM-001",
+            Amount = 15.00M,
+        };
+
         private static readonly Product Product = new("SquareId", "TLM-001", "Mandarin", "It's a Mandarin!", 45.00M);
 
         private readonly Mock<IFramePricesService> framePricesService = new();

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesNewViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesNewViewModelTests.cs
@@ -103,27 +103,27 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
                 canExecute.Should().BeFalse();
             }
 
-            [Theory]
-            [InlineData(1)]
-            [InlineData(2)]
-            [InlineData(3)]
-            public async Task ShouldNotBeAbleToExecuteWhenAnyRequiredPropertiesIsNotSet(int i)
+            [Fact]
+            public void ShouldDefaultCreatedAtToToday()
+            {
+                this.Subject.CreatedAt.Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(5));
+            }
+
+            [Fact]
+            public async Task ShouldNotBeAbleToExecuteWhenProductIsNotYetSelected()
             {
                 var subject = this.Subject;
-                if (i != 1)
-                {
-                    subject.SelectedProduct = this.fixture.Create<Product>();
-                }
+                subject.FrameAmount = this.fixture.Create<decimal>();
 
-                if (i != 2)
-                {
-                    subject.FrameAmount = this.fixture.Create<decimal>();
-                }
+                var canExecute = await subject.Save.CanExecute.FirstAsync();
+                canExecute.Should().BeFalse();
+            }
 
-                if (i != 3)
-                {
-                    subject.CreatedAt = this.fixture.Create<DateTime>();
-                }
+            [Fact]
+            public async Task ShouldNotBeAbleToExecuteWhenCommissionAmountIsNotYetSelected()
+            {
+                var subject = this.Subject;
+                subject.SelectedProduct = this.fixture.Create<Product>();
 
                 var canExecute = await subject.Save.CanExecute.FirstAsync();
                 canExecute.Should().BeFalse();

--- a/tests/Mandarin.Services.Tests/Transactions/TransactionMapperTests.cs
+++ b/tests/Mandarin.Services.Tests/Transactions/TransactionMapperTests.cs
@@ -45,7 +45,7 @@ namespace Mandarin.Services.Tests.Transactions
 
         private void GivenFramePriceExists(Product product, FramePrice framePrice)
         {
-            this.framePricesService.Setup(x => x.GetFramePriceAsync(product.ProductCode)).ReturnsAsync(framePrice);
+            this.framePricesService.Setup(x => x.GetFramePriceAsync(product.ProductCode, this.orderDate)).ReturnsAsync(framePrice);
         }
 
         private void GivenConfigurationWithMappings(Product product, Product mappedProduct)

--- a/tests/Mandarin.Services.Tests/Transactions/TransactionMapperTests.cs
+++ b/tests/Mandarin.Services.Tests/Transactions/TransactionMapperTests.cs
@@ -144,7 +144,11 @@ namespace Mandarin.Services.Tests.Transactions
             public async Task ShouldIncludeTheFramePriceAsATransaction()
             {
                 var product = TestData.Create<Product>();
-                var framePrice = new FramePrice(product.ProductCode, 1.00m);
+                var framePrice = new FramePrice
+                {
+                    ProductCode = product.ProductCode,
+                    Amount = 1.00m,
+                };
                 this.GivenInventoryServiceSetUpWithProduct(product);
                 this.GivenFramePriceExists(product, framePrice);
                 var order = this.GivenOrderProductAsLineItem(product);

--- a/tests/Mandarin.Tests/Helpers/Database/MandarinDbContextTestDataExtensions.cs
+++ b/tests/Mandarin.Tests/Helpers/Database/MandarinDbContextTestDataExtensions.cs
@@ -23,6 +23,7 @@ namespace Mandarin.Tests.Helpers.Database
             await connection.ExecuteAsync("DROP TABLE IF EXISTS inventory.stockist");
             await connection.ExecuteAsync("DROP TABLE IF EXISTS inventory.fixed_commission_amount");
             await connection.ExecuteAsync("DROP TABLE IF EXISTS inventory.frame_price");
+            await connection.ExecuteAsync("DROP PROCEDURE IF EXISTS inventory.sp_frame_price_upsert(TEXT, NUMERIC, TIMESTAMP)");
             await connection.ExecuteAsync("TRUNCATE TABLE public.schemaversions");
         }
     }


### PR DESCRIPTION
Added tracking of `created_at` and `active_until` to `frame_price`, which allows the record of sales calculation to track the correct price as of a specific date.
Allowed this to bubble up to the screen as a user editable field - upon updating this, there will be a stored procedure call instead as the logic to maintain a safe update is a little much to be performed within code.