### PR TITLE
Bump application dependencies. (July 2021)

### DIFF
--- a/src/Mandarin.Client.Services/Mandarin.Client.Services.csproj
+++ b/src/Mandarin.Client.Services/Mandarin.Client.Services.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client.Web" Version="2.36.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.36.0" />
+    <PackageReference Include="Grpc.Net.Client.Web" Version="2.38.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.38.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>

--- a/src/Mandarin.Client.ViewModels/Mandarin.Client.ViewModels.csproj
+++ b/src/Mandarin.Client.ViewModels/Mandarin.Client.ViewModels.csproj
@@ -6,11 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Blazorise" Version="0.9.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="ReactiveUI" Version="13.1.1" />
+    <PackageReference Include="ReactiveUI" Version="14.1.1" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Mandarin.Client/Mandarin.Client.csproj
+++ b/src/Mandarin.Client/Mandarin.Client.csproj
@@ -7,20 +7,20 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Bashi.Core" Version="3.0.0" />
+    <PackageReference Include="Bashi.Core" Version="4.0.0" />
     <PackageReference Include="Blazorise" Version="0.9.2.3" />
     <PackageReference Include="Blazorise.Bootstrap" Version="0.9.2.3" />
     <PackageReference Include="Blazorise.Components" Version="0.9.2.3" />
     <PackageReference Include="Blazorise.DataGrid" Version="0.9.2.3" />
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="0.9.2.3" />
-    <PackageReference Include="Grpc.Net.Client.Web" Version="2.36.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.36.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.4" PrivateAssets="all" />
+    <PackageReference Include="Grpc.Net.Client.Web" Version="2.38.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.38.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
-    <PackageReference Include="ReactiveUI.Blazor" Version="13.1.1" />
+    <PackageReference Include="ReactiveUI.Blazor" Version="14.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mandarin.Database/Mandarin.Database.csproj
+++ b/src/Mandarin.Database/Mandarin.Database.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="Bashi.Core" Version="3.0.0" />
+    <PackageReference Include="Bashi.Core" Version="4.0.0" />
     <PackageReference Include="Dapper" Version="2.0.90" />
     <PackageReference Include="dbup" Version="4.5.0" />
     <PackageReference Include="dbup-postgresql" Version="4.5.0" />

--- a/src/Mandarin.Interfaces.Grpc/Mandarin.Interfaces.Grpc.csproj
+++ b/src/Mandarin.Interfaces.Grpc/Mandarin.Interfaces.Grpc.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Google.Protobuf" Version="3.17.3" />
     <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.36.4">
+    <PackageReference Include="Grpc.Tools" Version="2.38.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Mandarin.Interfaces/Mandarin.Interfaces.csproj
+++ b/src/Mandarin.Interfaces/Mandarin.Interfaces.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="Bashi.Core" Version="3.0.0" />
+    <PackageReference Include="Bashi.Core" Version="4.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />

--- a/src/Mandarin.Services/Mandarin.Services.csproj
+++ b/src/Mandarin.Services/Mandarin.Services.csproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bashi.Core" Version="3.0.0" />
+    <PackageReference Include="Bashi.Core" Version="4.0.0" />
     <PackageReference Include="LazyCache" Version="2.1.3" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
-    <PackageReference Include="SendGrid" Version="9.22.0" />
+    <PackageReference Include="SendGrid" Version="9.24.0" />
     <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.0" />
-    <PackageReference Include="Square" Version="9.1.0" />
+    <PackageReference Include="Square" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mandarin/Mandarin.csproj
+++ b/src/Mandarin/Mandarin.csproj
@@ -13,14 +13,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.10.0" />
-    <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="1.5.1" />
-    <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.1" />
+    <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.11.0" />
+    <PackageReference Include="Elastic.Apm.SerilogEnricher" Version="1.5.3" />
+    <PackageReference Include="Elastic.CommonSchema.Serilog" Version="1.5.3" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.38.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.38.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />

--- a/tests/Mandarin.Client.Services.Tests/Mandarin.Client.Services.Tests.csproj
+++ b/tests/Mandarin.Client.Services.Tests/Mandarin.Client.Services.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bashi.Tests.Framework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mandarin.Client.ViewModels.Tests/Mandarin.Client.ViewModels.Tests.csproj
+++ b/tests/Mandarin.Client.ViewModels.Tests/Mandarin.Client.ViewModels.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.14.0" />
+    <PackageReference Include="AngleSharp" Version="0.16.0" />
     <PackageReference Include="Bashi.Tests.Framework" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mandarin.Tests.Data/Mandarin.Tests.Data.csproj
+++ b/tests/Mandarin.Tests.Data/Mandarin.Tests.Data.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="Square" Version="9.1.0" />
+    <PackageReference Include="Square" Version="12.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Mandarin.Tests/Mandarin.Tests.csproj
+++ b/tests/Mandarin.Tests/Mandarin.Tests.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.14.0" />
+    <PackageReference Include="AngleSharp" Version="0.16.0" />
     <PackageReference Include="Bashi.Tests.Framework" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="5.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.7" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="2.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
Bumping all but Blazorise as last update I saw had some odd issues with the Record of Sales.