### PR TITLE
BASHI-125: Refactor artist pages to use MVVM.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: "[Setup] Install .NET Core"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: 5.0.301
 
       - name: "[Setup] Install node"
         if: github.event_name == 'release'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.304" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)/stylecop.json" Link="stylecop.json"/>
   </ItemGroup>
 

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistValidator.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistValidator.cs
@@ -1,0 +1,30 @@
+﻿using FluentValidation;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <summary>
+    /// Represents a <see cref="IValidator{T}"/> for <see cref="IArtistViewModel"/>.
+    /// </summary>
+    internal sealed class ArtistValidator : AbstractValidator<IArtistViewModel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtistValidator"/> class.
+        /// </summary>
+        public ArtistValidator()
+        {
+            this.RuleFor(x => x.StockistCode).NotEmpty().MaximumLength(6);
+            this.RuleFor(x => x.FirstName).NotEmpty().MaximumLength(100);
+            this.RuleFor(x => x.LastName).MaximumLength(100);
+            this.RuleFor(x => x.DisplayName).NotEmpty().MaximumLength(250);
+            this.RuleFor(x => x.EmailAddress).EmailAddress().MaximumLength(100);
+            this.RuleFor(x => x.TwitterHandle).MaximumLength(30);
+            this.RuleFor(x => x.FacebookHandle).MaximumLength(30);
+            this.RuleFor(x => x.InstagramHandle).MaximumLength(30);
+            this.RuleFor(x => x.TumblrHandle).MaximumLength(30);
+            this.RuleFor(x => x.WebsiteUrl).MaximumLength(150);
+            this.RuleFor(x => x.Rate).InclusiveBetween(0, 100);
+            this.RuleFor(x => x.StartDate).LessThan(x => x.EndDate);
+            this.RuleFor(x => x.EndDate).GreaterThan(x => x.StartDate);
+        }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Mandarin.Commissions;
 using Mandarin.Common;
 using Mandarin.Stockists;
 using ReactiveUI;
@@ -29,6 +30,7 @@ namespace Mandarin.Client.ViewModels.Artists
         /// <param name="stockist">The pre-existing stockist to populate from.</param>
         public ArtistViewModel(Stockist stockist)
         {
+            this.StockistId = stockist.StockistId;
             this.stockistCode = stockist.StockistCode;
             this.statusCode = stockist.StatusCode;
             this.firstName = stockist.Details.FirstName;
@@ -40,10 +42,14 @@ namespace Mandarin.Client.ViewModels.Artists
             this.websiteUrl = stockist.Details.WebsiteUrl;
             this.tumblrHandle = stockist.Details.TumblrHandle;
             this.emailAddress = stockist.Details.EmailAddress;
+            this.CommissionId = stockist.Commission.CommissionId;
             this.startDate = stockist.Commission.StartDate;
             this.endDate = stockist.Commission.EndDate;
             this.rate = stockist.Commission.Rate;
         }
+
+        /// <inheritdoc />
+        public int StockistId { get; }
 
         /// <inheritdoc />
         public string StockistCode
@@ -122,6 +128,9 @@ namespace Mandarin.Client.ViewModels.Artists
             set => this.RaiseAndSetIfChanged(ref this.emailAddress, value);
         }
 
+        /// <inheritdoc/>
+        public int CommissionId { get; }
+
         /// <inheritdoc />
         public DateTime StartDate
         {
@@ -141,6 +150,39 @@ namespace Mandarin.Client.ViewModels.Artists
         {
             get => this.rate;
             set => this.RaiseAndSetIfChanged(ref this.rate, value);
+        }
+
+        /// <inheritdoc/>
+        public Stockist ToStockist()
+        {
+            return new Stockist
+            {
+                StockistId = this.StockistId,
+                StockistCode = this.stockistCode,
+                StatusCode = this.statusCode,
+                Details = new StockistDetail
+                {
+                    StockistId = this.StockistId,
+                    FirstName = this.FirstName,
+                    LastName = this.LastName,
+                    DisplayName = this.DisplayName,
+                    TwitterHandle = this.TwitterHandle,
+                    InstagramHandle = this.InstagramHandle,
+                    FacebookHandle = this.FacebookHandle,
+                    WebsiteUrl = this.WebsiteUrl,
+                    TumblrHandle = this.TumblrHandle,
+                    EmailAddress = this.EmailAddress,
+                },
+                Commission = new Commission
+                {
+                    CommissionId = this.CommissionId,
+                    StockistId = this.StockistId,
+                    Rate = this.Rate,
+                    StartDate = this.StartDate,
+                    EndDate = this.EndDate,
+                    InsertedAt = DateTime.Now,
+                },
+            };
         }
     }
 }

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Mandarin.Common;
+using Mandarin.Stockists;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <inheritdoc cref="IArtistViewModel" />
+    internal sealed class ArtistViewModel : ReactiveObject, IArtistViewModel
+    {
+        private string stockistCode;
+        private StatusMode statusCode;
+        private string firstName;
+        private string lastName;
+        private string displayName;
+        private string twitterHandle;
+        private string instagramHandle;
+        private string facebookHandle;
+        private string websiteUrl;
+        private string tumblrHandle;
+        private string emailAddress;
+        private DateTime startDate;
+        private DateTime endDate;
+        private int rate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtistViewModel"/> class.
+        /// </summary>
+        /// <param name="stockist">The pre-existing stockist to populate from.</param>
+        public ArtistViewModel(Stockist stockist)
+        {
+            this.stockistCode = stockist.StockistCode;
+            this.statusCode = stockist.StatusCode;
+            this.firstName = stockist.Details.FirstName;
+            this.lastName = stockist.Details.LastName;
+            this.displayName = stockist.Details.DisplayName;
+            this.twitterHandle = stockist.Details.TwitterHandle;
+            this.instagramHandle = stockist.Details.InstagramHandle;
+            this.facebookHandle = stockist.Details.FacebookHandle;
+            this.websiteUrl = stockist.Details.WebsiteUrl;
+            this.tumblrHandle = stockist.Details.TumblrHandle;
+            this.emailAddress = stockist.Details.EmailAddress;
+            this.startDate = stockist.Commission.StartDate;
+            this.endDate = stockist.Commission.EndDate;
+            this.rate = stockist.Commission.Rate;
+        }
+
+        /// <inheritdoc />
+        public string StockistCode
+        {
+            get => this.stockistCode;
+            set => this.RaiseAndSetIfChanged(ref this.stockistCode, value);
+        }
+
+        /// <inheritdoc />
+        public StatusMode StatusCode
+        {
+            get => this.statusCode;
+            set => this.RaiseAndSetIfChanged(ref this.statusCode, value);
+        }
+
+        /// <inheritdoc />
+        public string FirstName
+        {
+            get => this.firstName;
+            set => this.RaiseAndSetIfChanged(ref this.firstName, value);
+        }
+
+        /// <inheritdoc />
+        public string LastName
+        {
+            get => this.lastName;
+            set => this.RaiseAndSetIfChanged(ref this.lastName, value);
+        }
+
+        /// <inheritdoc />
+        public string DisplayName
+        {
+            get => this.displayName;
+            set => this.RaiseAndSetIfChanged(ref this.displayName, value);
+        }
+
+        /// <inheritdoc />
+        public string TwitterHandle
+        {
+            get => this.twitterHandle;
+            set => this.RaiseAndSetIfChanged(ref this.twitterHandle, value);
+        }
+
+        /// <inheritdoc />
+        public string InstagramHandle
+        {
+            get => this.instagramHandle;
+            set => this.RaiseAndSetIfChanged(ref this.instagramHandle, value);
+        }
+
+        /// <inheritdoc />
+        public string FacebookHandle
+        {
+            get => this.facebookHandle;
+            set => this.RaiseAndSetIfChanged(ref this.facebookHandle, value);
+        }
+
+        /// <inheritdoc />
+        public string WebsiteUrl
+        {
+            get => this.websiteUrl;
+            set => this.RaiseAndSetIfChanged(ref this.websiteUrl, value);
+        }
+
+        /// <inheritdoc />
+        public string TumblrHandle
+        {
+            get => this.tumblrHandle;
+            set => this.RaiseAndSetIfChanged(ref this.tumblrHandle, value);
+        }
+
+        /// <inheritdoc />
+        public string EmailAddress
+        {
+            get => this.emailAddress;
+            set => this.RaiseAndSetIfChanged(ref this.emailAddress, value);
+        }
+
+        /// <inheritdoc />
+        public DateTime StartDate
+        {
+            get => this.startDate;
+            set => this.RaiseAndSetIfChanged(ref this.startDate, value);
+        }
+
+        /// <inheritdoc />
+        public DateTime EndDate
+        {
+            get => this.endDate;
+            set => this.RaiseAndSetIfChanged(ref this.endDate, value);
+        }
+
+        /// <inheritdoc />
+        public int Rate
+        {
+            get => this.rate;
+            set => this.RaiseAndSetIfChanged(ref this.rate, value);
+        }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
@@ -158,8 +158,8 @@ namespace Mandarin.Client.ViewModels.Artists
             return new Stockist
             {
                 StockistId = this.StockistId,
-                StockistCode = this.stockistCode,
-                StatusCode = this.statusCode,
+                StockistCode = this.StockistCode,
+                StatusCode = this.StatusCode,
                 Details = new StockistDetail
                 {
                     StockistId = this.StockistId,

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistsEditViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistsEditViewModel.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
+using Bashi.Core.Extensions;
+using Bashi.Core.Utils;
+using FluentValidation;
+using FluentValidation.Results;
+using Mandarin.Common;
+using Mandarin.Stockists;
+using Microsoft.AspNetCore.Components;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <inheritdoc cref="IArtistsEditViewModel" />
+    internal sealed class ArtistsEditViewModel : ReactiveObject, IArtistsEditViewModel
+    {
+        private readonly IStockistService stockistService;
+        private readonly NavigationManager navigationManager;
+        private readonly IValidator<IArtistViewModel> validator;
+        private readonly ObservableAsPropertyHelper<bool> isLoading;
+
+        private IArtistViewModel stockist;
+        private ValidationResult validationResult;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtistsEditViewModel"/> class.
+        /// </summary>
+        /// <param name="stockistService">The application service for interacting with stockists.</param>
+        /// <param name="navigationManager">The service for querying and changing the current URL.</param>
+        /// <param name="validator">The validator for the Stockist to ensure it can be saved.</param>
+        public ArtistsEditViewModel(IStockistService stockistService, NavigationManager navigationManager, IValidator<IArtistViewModel> validator)
+        {
+            this.stockistService = stockistService;
+            this.navigationManager = navigationManager;
+            this.validator = validator;
+
+            this.LoadData = ReactiveCommand.CreateFromTask<string>(this.OnLoadData);
+            this.Save = ReactiveCommand.CreateFromTask(this.OnSave);
+            this.Cancel = ReactiveCommand.Create(this.OnCancel);
+
+            this.isLoading = this.LoadData.IsExecuting.ToProperty(this, x => x.IsLoading);
+            this.Statuses = EnumUtil.GetValues<StatusMode>().Except(new[] { StatusMode.Unknown }).AsReadOnlyList();
+        }
+
+        /// <inheritdoc />
+        public bool IsLoading => this.isLoading.Value;
+
+        /// <inheritdoc />
+        public IArtistViewModel Stockist
+        {
+            get => this.stockist;
+            private set => this.RaiseAndSetIfChanged(ref this.stockist, value);
+        }
+
+        /// <inheritdoc />
+        public ValidationResult ValidationResult
+        {
+            get => this.validationResult;
+            private set => this.RaiseAndSetIfChanged(ref this.validationResult, value);
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<StatusMode> Statuses { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<string, Unit> LoadData { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, Unit> Save { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, Unit> Cancel { get; }
+
+        private async Task OnLoadData(string stockistCode)
+        {
+            var existingStockist = await this.stockistService.GetStockistByCodeAsync(stockistCode);
+            this.Stockist = new ArtistViewModel(existingStockist);
+        }
+
+        private async Task OnSave()
+        {
+            this.ValidationResult = await this.validator.ValidateAsync(this.Stockist);
+            if (!this.ValidationResult.IsValid)
+            {
+                return;
+            }
+
+            await this.stockistService.SaveStockistAsync(this.Stockist.ToStockist());
+            this.navigationManager.NavigateTo("/artists");
+        }
+
+        private void OnCancel() => this.navigationManager.NavigateTo("/artists");
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistsIndexViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistsIndexViewModel.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Bashi.Core.Extensions;
+using Mandarin.Client.ViewModels.Shared;
+using Mandarin.Stockists;
+using Microsoft.AspNetCore.Components;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <inheritdoc cref="IArtistsIndexViewModel" />
+    internal sealed class ArtistsIndexViewModel : IndexPageViewModelBase<IArtistViewModel>, IArtistsIndexViewModel
+    {
+        private readonly IStockistService stockistService;
+        private readonly NavigationManager navigationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtistsIndexViewModel"/> class.
+        /// </summary>
+        /// <param name="stockistService">The application service for interacting with stockists.</param>
+        /// <param name="navigationManager">The service for querying and changing the current URL.</param>
+        public ArtistsIndexViewModel(IStockistService stockistService, NavigationManager navigationManager)
+        {
+            this.stockistService = stockistService;
+            this.navigationManager = navigationManager;
+        }
+
+        /// <inheritdoc/>
+        protected override async Task<IReadOnlyCollection<IArtistViewModel>> OnLoadData()
+        {
+            var stockists = await this.stockistService.GetStockistsAsync();
+            return stockists.Select(CreateViewModel).AsReadOnlyList();
+
+            static IArtistViewModel CreateViewModel(Stockist stockist)
+            {
+                return new ArtistViewModel(stockist);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnCreateNew() => this.navigationManager.NavigateTo("/artists/new");
+
+        /// <inheritdoc/>
+        protected override void OnEditSelected() => this.navigationManager.NavigateTo($"/artists/edit/{this.SelectedRow.StockistCode}");
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/ArtistsNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistsNewViewModel.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Threading.Tasks;
+using Bashi.Core.Extensions;
+using Bashi.Core.Utils;
+using Mandarin.Commissions;
+using Mandarin.Common;
+using Mandarin.Stockists;
+using Microsoft.AspNetCore.Components;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <inheritdoc cref="IArtistsNewViewModel" />
+    internal sealed class ArtistsNewViewModel : ReactiveObject, IArtistsNewViewModel
+    {
+        private readonly IStockistService stockistService;
+        private readonly NavigationManager navigationManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArtistsNewViewModel"/> class.
+        /// </summary>
+        /// <param name="stockistService">The application service for interacting with stockists.</param>
+        /// <param name="navigationManager">The service for querying and changing the current URL.</param>
+        public ArtistsNewViewModel(IStockistService stockistService, NavigationManager navigationManager)
+        {
+            this.stockistService = stockistService;
+            this.navigationManager = navigationManager;
+
+            this.Save = ReactiveCommand.CreateFromTask(this.OnSave);
+            this.Cancel = ReactiveCommand.Create(this.OnCancel);
+
+            this.Stockist = new ArtistViewModel(new Stockist
+            {
+                StatusCode = StatusMode.Active,
+                Details = new StockistDetail(),
+                Commission = new Commission
+                {
+                    Rate = 100,
+                    StartDate = DateTime.Now.Date,
+                    EndDate = DateTime.Now.AddDays(90).Date,
+                },
+            });
+            this.Statuses = EnumUtil.GetValues<StatusMode>().Except(new[] { StatusMode.Unknown }).AsReadOnlyList();
+        }
+
+        /// <inheritdoc />
+        public IArtistViewModel Stockist { get; }
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<StatusMode> Statuses { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, Unit> Save { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, Unit> Cancel { get; }
+
+        private async Task OnSave()
+        {
+            await this.stockistService.SaveStockistAsync(this.Stockist.ToStockist());
+            this.navigationManager.NavigateTo($"/artists/edit/{this.Stockist.StockistCode}");
+        }
+
+        private void OnCancel() => this.navigationManager.NavigateTo("/inventory/frame-prices");
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/IArtistViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/IArtistViewModel.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using Mandarin.Common;
+using Mandarin.Stockists;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <summary>
+    /// Represents a <see cref="Stockist"/> for viewing/editing.
+    /// </summary>
+    public interface IArtistViewModel : IReactiveObject
+    {
+        /// <summary>
+        /// Gets or sets the Stockist's user-friendly code.
+        /// </summary>
+        [Required]
+        [StringLength(6)]
+        public string StockistCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reference to the stockist's current active status.
+        /// </summary>
+        public StatusMode StatusCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Stockist's first name.
+        /// </summary>
+        [StringLength(100)]
+        public string FirstName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Stockist's last name.
+        /// </summary>
+        [StringLength(100)]
+        public string LastName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Stockist's artist/display name.
+        /// </summary>
+        [Required]
+        [StringLength(250)]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stockist's twitter handle.
+        /// </summary>
+        [MaxLength(30)]
+        public string TwitterHandle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stockist's instagram handle.
+        /// </summary>
+        [MaxLength(30)]
+        public string InstagramHandle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stockist's facebook handle.
+        /// </summary>
+        [MaxLength(30)]
+        public string FacebookHandle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stockist's personal website url.
+        /// </summary>
+        [Url]
+        [MaxLength(150)]
+        public string WebsiteUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stockist's tumblr handle.
+        /// </summary>
+        [MaxLength(30)]
+        public string TumblrHandle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stockist's email address.
+        /// </summary>
+        [EmailAddress]
+        [MaxLength(100)]
+        public string EmailAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start date for this commission.
+        /// </summary>
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the end date for this commission.
+        /// </summary>
+        [Required]
+        public DateTime EndDate { get; set; }
+
+        /// <summary>
+        ///  Gets or sets the agreed commission rate group for this commission.
+        /// </summary>
+        [Required]
+        public int Rate { get; set; }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/IArtistViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/IArtistViewModel.cs
@@ -12,6 +12,11 @@ namespace Mandarin.Client.ViewModels.Artists
     public interface IArtistViewModel : IReactiveObject
     {
         /// <summary>
+        /// Gets the Stockist's unique ID.
+        /// </summary>
+        public int StockistId { get; }
+
+        /// <summary>
         /// Gets or sets the Stockist's user-friendly code.
         /// </summary>
         [Required]
@@ -81,6 +86,11 @@ namespace Mandarin.Client.ViewModels.Artists
         public string EmailAddress { get; set; }
 
         /// <summary>
+        /// Gets the stockist's latest commission id.
+        /// </summary>
+        public int CommissionId { get; }
+
+        /// <summary>
         /// Gets or sets the start date for this commission.
         /// </summary>
         [Required]
@@ -93,9 +103,15 @@ namespace Mandarin.Client.ViewModels.Artists
         public DateTime EndDate { get; set; }
 
         /// <summary>
-        ///  Gets or sets the agreed commission rate group for this commission.
+        /// Gets or sets the agreed commission rate group for this commission.
         /// </summary>
         [Required]
         public int Rate { get; set; }
+
+        /// <summary>
+        /// Builds the complete <see cref="Stockist"/> from the current values in the ViewModel.
+        /// </summary>
+        /// <returns>The fully populated <see cref="Stockist"/>.</returns>
+        public Stockist ToStockist();
     }
 }

--- a/src/Mandarin.Client.ViewModels/Artists/IArtistsEditViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/IArtistsEditViewModel.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Reactive;
+using Mandarin.Common;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <summary>
+    /// Represents the ViewModel for creating a new <see cref="Mandarin.Stockists.Stockist"/>.
+    /// </summary>
+    public interface IArtistsEditViewModel : IValidatableViewModel
+    {
+        /// <summary>
+        /// Gets a value indicating whether gets whether the ViewModel has finished initialisation.
+        /// </summary>
+        bool IsLoading { get; }
+
+        /// <summary>
+        /// Gets the updatable ViewModel representing a <see cref="Mandarin.Stockists.Stockist"/>.
+        /// </summary>
+        IArtistViewModel Stockist { get; }
+
+        /// <summary>
+        /// Gets the set of all available statuses that a <see cref="Mandarin.Stockists.Stockist"/> can be in.
+        /// </summary>
+        IReadOnlyCollection<StatusMode> Statuses { get; }
+
+        /// <summary>
+        /// Gets the command to load the selected <see cref="Mandarin.Stockists.Stockist"/> into <see cref="Stockist"/>.
+        /// </summary>
+        ReactiveCommand<string, Unit> LoadData { get; }
+
+        /// <summary>
+        /// Gets the command to save the newly created <see cref="Mandarin.Stockists.Stockist"/>.
+        /// </summary>
+        ReactiveCommand<Unit, Unit> Save { get; }
+
+        /// <summary>
+        /// Gets the command to cancel and go back to viewing existing <see cref="Mandarin.Stockists.Stockist"/>s.
+        /// </summary>
+        ReactiveCommand<Unit, Unit> Cancel { get; }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/IArtistsIndexViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/IArtistsIndexViewModel.cs
@@ -1,0 +1,12 @@
+﻿using Mandarin.Client.ViewModels.Shared;
+using Mandarin.Stockists;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <summary>
+    /// Represents the ViewModel for viewing all existing <see cref="Stockist"/> instances.
+    /// </summary>
+    public interface IArtistsIndexViewModel : IIndexPageViewModel<IArtistViewModel>
+    {
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/IArtistsNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/IArtistsNewViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Reactive;
+using Mandarin.Common;
+using Mandarin.Inventory;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Artists
+{
+    /// <summary>
+    /// Represents the ViewModel for creating a new <see cref="Mandarin.Stockists.Stockist"/>.
+    /// </summary>
+    public interface IArtistsNewViewModel : IReactiveObject
+    {
+        /// <summary>
+        /// Gets the updatable ViewModel representing a <see cref="Mandarin.Stockists.Stockist"/>.
+        /// </summary>
+        IArtistViewModel Stockist { get; }
+
+        /// <summary>
+        /// Gets the set of all available statuses that a <see cref="Mandarin.Stockists.Stockist"/> can be in.
+        /// </summary>
+        IReadOnlyCollection<StatusMode> Statuses { get; }
+
+        /// <summary>
+        /// Gets the command to save the newly created <see cref="Mandarin.Stockists.Stockist"/>.
+        /// </summary>
+        ReactiveCommand<Unit, Unit> Save { get; }
+
+        /// <summary>
+        /// Gets the command to cancel and go back to viewing existing <see cref="Mandarin.Stockists.Stockist"/>s.
+        /// </summary>
+        ReactiveCommand<Unit, Unit> Cancel { get; }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Artists/IArtistsNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/IArtistsNewViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Reactive;
 using Mandarin.Common;
-using Mandarin.Inventory;
 using ReactiveUI;
 
 namespace Mandarin.Client.ViewModels.Artists
@@ -9,7 +8,7 @@ namespace Mandarin.Client.ViewModels.Artists
     /// <summary>
     /// Represents the ViewModel for creating a new <see cref="Mandarin.Stockists.Stockist"/>.
     /// </summary>
-    public interface IArtistsNewViewModel : IReactiveObject
+    public interface IArtistsNewViewModel : IValidatableViewModel
     {
         /// <summary>
         /// Gets the updatable ViewModel representing a <see cref="Mandarin.Stockists.Stockist"/>.

--- a/src/Mandarin.Client.ViewModels/IValidatableViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/IValidatableViewModel.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation.Results;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels
+{
+    /// <summary>
+    /// Represents a ViewModel that provides validation automatically when attempting actions.
+    /// </summary>
+    public interface IValidatableViewModel : IReactiveObject
+    {
+        /// <summary>
+        /// Gets the result of the last attempt to validate the current state.
+        /// </summary>
+        ValidationResult ValidationResult { get; }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesNewViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePricesNewViewModel.cs
@@ -5,7 +5,6 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
-using Blazorise.Utils;
 using Mandarin.Client.ViewModels.Extensions;
 using Mandarin.Inventory;
 using Microsoft.AspNetCore.Components;

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePriceGridRowViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePriceGridRowViewModel.cs
@@ -1,9 +1,11 @@
-﻿namespace Mandarin.Client.ViewModels.Inventory.FramePrices
+﻿using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Inventory.FramePrices
 {
     /// <summary>
     /// Represents a <see cref="Mandarin.Inventory.FramePrice"/> for display in a grid.
     /// </summary>
-    public interface IFramePriceGridRowViewModel
+    public interface IFramePriceGridRowViewModel : IReactiveObject
     {
         /// <summary>
         /// Gets the code of the product associated to the <see cref="Mandarin.Inventory.FramePrice"/>.

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePricesIndexViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/IFramePricesIndexViewModel.cs
@@ -1,44 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Reactive;
+﻿using Mandarin.Client.ViewModels.Shared;
 using Mandarin.Inventory;
-using ReactiveUI;
 
 namespace Mandarin.Client.ViewModels.Inventory.FramePrices
 {
     /// <summary>
     /// Represents the ViewModel for viewing all existing <see cref="FramePrice"/> instances.
     /// </summary>
-    public interface IFramePricesIndexViewModel : IReactiveObject
+    public interface IFramePricesIndexViewModel : IIndexPageViewModel<IFramePriceGridRowViewModel>
     {
-        /// <summary>
-        /// Gets a value indicating whether gets whether the ViewModel has finished initialisation.
-        /// </summary>
-        public bool IsLoading { get; }
-
-        /// <summary>
-        /// Gets the command to populate the ViewModel with data.
-        /// </summary>
-        ReactiveCommand<Unit, IReadOnlyCollection<IFramePriceGridRowViewModel>> LoadData { get; }
-
-        /// <summary>
-        /// Gets the command to create a new <see cref="FramePrice"/>.
-        /// </summary>
-        ReactiveCommand<Unit, Unit> CreateNew { get; }
-
-        /// <summary>
-        /// Gets the command to edit the selected <see cref="FramePrice"/>.
-        /// </summary>
-        ReactiveCommand<Unit, Unit> EditSelected { get; }
-
-        /// <summary>
-        /// Gets the collection of all known <see cref="FramePrice"/> instances.
-        /// </summary>
-        ReadOnlyObservableCollection<IFramePriceGridRowViewModel> Rows { get; }
-
-        /// <summary>
-        /// Gets or sets the selected <see cref="FramePrice"/>.
-        /// </summary>
-        IFramePriceGridRowViewModel SelectedRow { get; set; }
     }
 }

--- a/src/Mandarin.Client.ViewModels/Mandarin.Client.ViewModels.csproj
+++ b/src/Mandarin.Client.ViewModels/Mandarin.Client.ViewModels.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Blazorise" Version="0.9.2.3" />
+    <PackageReference Include="FluentValidation" Version="10.2.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />

--- a/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
+++ b/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace Mandarin.Client.ViewModels
             services.AddTransient<IIndexViewModel, IndexViewModel>();
 
             services.AddTransient<IArtistsIndexViewModel, ArtistsIndexViewModel>();
+            services.AddTransient<IArtistsNewViewModel, ArtistsNewViewModel>();
 
             services.AddTransient<IFramePricesIndexViewModel, FramePricesIndexViewModel>();
             services.AddTransient<IFramePricesEditViewModel, FramePricesEditViewModel>();

--- a/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
+++ b/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ namespace Mandarin.Client.ViewModels
 
             services.AddTransient<IValidator<IArtistViewModel>, ArtistValidator>();
             services.AddTransient<IArtistsIndexViewModel, ArtistsIndexViewModel>();
+            services.AddTransient<IArtistsEditViewModel, ArtistsEditViewModel>();
             services.AddTransient<IArtistsNewViewModel, ArtistsNewViewModel>();
 
             services.AddTransient<IFramePricesIndexViewModel, FramePricesIndexViewModel>();

--- a/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
+++ b/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Mandarin.Client.ViewModels.Index;
+﻿using Mandarin.Client.ViewModels.Artists;
+using Mandarin.Client.ViewModels.Index;
 using Mandarin.Client.ViewModels.Inventory.FramePrices;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +18,9 @@ namespace Mandarin.Client.ViewModels
         public static IServiceCollection AddMandarinViewModels(this IServiceCollection services)
         {
             services.AddTransient<IIndexViewModel, IndexViewModel>();
+
+            services.AddTransient<IArtistsIndexViewModel, ArtistsIndexViewModel>();
+
             services.AddTransient<IFramePricesIndexViewModel, FramePricesIndexViewModel>();
             services.AddTransient<IFramePricesEditViewModel, FramePricesEditViewModel>();
             services.AddTransient<IFramePricesNewViewModel, FramePricesNewViewModel>();

--- a/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
+++ b/src/Mandarin.Client.ViewModels/MandarinViewModelsServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Mandarin.Client.ViewModels.Artists;
+﻿using FluentValidation;
+using Mandarin.Client.ViewModels.Artists;
 using Mandarin.Client.ViewModels.Index;
 using Mandarin.Client.ViewModels.Inventory.FramePrices;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,7 @@ namespace Mandarin.Client.ViewModels
         {
             services.AddTransient<IIndexViewModel, IndexViewModel>();
 
+            services.AddTransient<IValidator<IArtistViewModel>, ArtistValidator>();
             services.AddTransient<IArtistsIndexViewModel, ArtistsIndexViewModel>();
             services.AddTransient<IArtistsNewViewModel, ArtistsNewViewModel>();
 

--- a/src/Mandarin.Client.ViewModels/Shared/IIndexPageViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Shared/IIndexPageViewModel.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reactive;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Shared
+{
+    /// <summary>
+    /// Represents a ViewModel for viewing all existing instances of <typeparamref name="TRowViewModel"/>.
+    /// </summary>
+    /// <typeparam name="TRowViewModel">The type of the ViewModel.</typeparam>
+    public interface IIndexPageViewModel<TRowViewModel> : IReactiveObject
+    {
+        /// <summary>
+        /// Gets a value indicating whether gets whether the ViewModel has finished initialisation.
+        /// </summary>
+        public bool IsLoading { get; }
+
+        /// <summary>
+        /// Gets the command to populate the ViewModel with data.
+        /// </summary>
+        ReactiveCommand<Unit, IReadOnlyCollection<TRowViewModel>> LoadData { get; }
+
+        /// <summary>
+        /// Gets the command to create a new <typeparamref name="TRowViewModel"/>.
+        /// </summary>
+        ReactiveCommand<Unit, Unit> CreateNew { get; }
+
+        /// <summary>
+        /// Gets the command to edit the selected <typeparamref name="TRowViewModel"/>.
+        /// </summary>
+        ReactiveCommand<Unit, Unit> EditSelected { get; }
+
+        /// <summary>
+        /// Gets the collection of all known <typeparamref name="TRowViewModel"/> instances.
+        /// </summary>
+        ReadOnlyObservableCollection<TRowViewModel> Rows { get; }
+
+        /// <summary>
+        /// Gets or sets the selected <typeparamref name="TRowViewModel"/>.
+        /// </summary>
+        TRowViewModel SelectedRow { get; set; }
+    }
+}

--- a/src/Mandarin.Client.ViewModels/Shared/IIndexPageViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Shared/IIndexPageViewModel.cs
@@ -14,7 +14,7 @@ namespace Mandarin.Client.ViewModels.Shared
         /// <summary>
         /// Gets a value indicating whether gets whether the ViewModel has finished initialisation.
         /// </summary>
-        public bool IsLoading { get; }
+        bool IsLoading { get; }
 
         /// <summary>
         /// Gets the command to populate the ViewModel with data.

--- a/src/Mandarin.Client.ViewModels/Shared/IndexPageViewModelBase.cs
+++ b/src/Mandarin.Client.ViewModels/Shared/IndexPageViewModelBase.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Mandarin.Client.ViewModels.Extensions;
+using ReactiveUI;
+
+namespace Mandarin.Client.ViewModels.Shared
+{
+    /// <inheritdoc cref="IIndexPageViewModel{TRowViewModel}" />
+    internal abstract class IndexPageViewModelBase<TRowViewModel> : ReactiveObject, IIndexPageViewModel<TRowViewModel>
+        where TRowViewModel : IReactiveObject
+    {
+        private readonly ObservableAsPropertyHelper<bool> isLoading;
+
+        private TRowViewModel selectedRow;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IndexPageViewModelBase{TRowViewModel}"/> class.
+        /// </summary>
+        protected IndexPageViewModelBase()
+        {
+            var rows = new ObservableCollection<TRowViewModel>();
+            this.Rows = new ReadOnlyObservableCollection<TRowViewModel>(rows);
+
+            this.LoadData = ReactiveCommand.CreateFromTask(this.OnLoadData);
+            this.CreateNew = ReactiveCommand.Create(this.OnCreateNew);
+            this.EditSelected = ReactiveCommand.Create(this.OnEditSelected, this.WhenAnyValue(x => x.SelectedRow).Select(x => x != null));
+
+            this.isLoading = this.LoadData.IsExecuting.ToProperty(this, x => x.IsLoading);
+            this.LoadData.Subscribe(x => rows.Reset(x));
+        }
+
+        /// <inheritdoc />
+        public bool IsLoading => this.isLoading.Value;
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, IReadOnlyCollection<TRowViewModel>> LoadData { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, Unit> CreateNew { get; }
+
+        /// <inheritdoc />
+        public ReactiveCommand<Unit, Unit> EditSelected { get; }
+
+        /// <inheritdoc />
+        public ReadOnlyObservableCollection<TRowViewModel> Rows { get; }
+
+        /// <inheritdoc />
+        public TRowViewModel SelectedRow
+        {
+            get => this.selectedRow;
+            set => this.RaiseAndSetIfChanged(ref this.selectedRow, value);
+        }
+
+        /// <summary>
+        /// Loads all rows to be populated into <see cref="Rows"/>.
+        /// </summary>
+        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        protected abstract Task<IReadOnlyCollection<TRowViewModel>> OnLoadData();
+
+        /// <summary>
+        /// Handles the request to create a new <typeparamref name="TRowViewModel"/>.
+        /// </summary>
+        protected abstract void OnCreateNew();
+
+        /// <summary>
+        /// Handles the request to update the <typeparamref name="TRowViewModel"/> referenced by <see cref="SelectedRow"/>.
+        /// </summary>
+        protected abstract void OnEditSelected();
+    }
+}

--- a/src/Mandarin.Client/Components/Inputs/MandarinIcon.cs
+++ b/src/Mandarin.Client/Components/Inputs/MandarinIcon.cs
@@ -1,0 +1,35 @@
+﻿using IconStyle = Blazorise.IconStyle;
+
+namespace Mandarin.Client.Components.Inputs
+{
+    /// <summary>
+    /// Represents a wrapper for a FontAwesome Icon.
+    /// </summary>
+    public sealed record MandarinIcon(string IconClass, string IconName, IconStyle IconStyle)
+    {
+        /// <summary>
+        /// Represents the Twitter FontAwesome Icon.
+        /// </summary>
+        public static readonly MandarinIcon Twitter = new("fab", "fa-twitter", IconStyle.Light);
+
+        /// <summary>
+        /// Represents the Facebook FontAwesome Icon.
+        /// </summary>
+        public static readonly MandarinIcon Facebook = new("fab", "fa-facebook", IconStyle.Light);
+
+        /// <summary>
+        /// Represents the Instagram FontAwesome Icon.
+        /// </summary>
+        public static readonly MandarinIcon Instagram = new("fab", "fa-instagram", IconStyle.Light);
+
+        /// <summary>
+        /// Represents the Tumblr FontAwesome Icon.
+        /// </summary>
+        public static readonly MandarinIcon Tumblr = new("fab", "fa-tumblr", IconStyle.Light);
+
+        /// <summary>
+        /// Represents the Url FontAwesome Icon.
+        /// </summary>
+        public static readonly MandarinIcon Url = new(string.Empty, "fa-globe-europe", IconStyle.Solid);
+    }
+}

--- a/src/Mandarin.Client/Components/Inputs/MandarinIcon.cs
+++ b/src/Mandarin.Client/Components/Inputs/MandarinIcon.cs
@@ -1,10 +1,13 @@
-﻿using IconStyle = Blazorise.IconStyle;
+﻿using Blazorise;
 
 namespace Mandarin.Client.Components.Inputs
 {
     /// <summary>
     /// Represents a wrapper for a FontAwesome Icon.
     /// </summary>
+    /// <param name="IconClass">The CSS class family that the FontAwesome Icon belongs to.</param>
+    /// <param name="IconName">The CSS class that identifies the FontAwesome Icon.</param>
+    /// <param name="IconStyle">The Icon style weight to be set.</param>
     public sealed record MandarinIcon(string IconClass, string IconName, IconStyle IconStyle)
     {
         /// <summary>

--- a/src/Mandarin.Client/Components/Inputs/ValidatedDateEdit.razor
+++ b/src/Mandarin.Client/Components/Inputs/ValidatedDateEdit.razor
@@ -1,0 +1,41 @@
+﻿@inherits ValidatedEditBase
+@typeparam TValue
+
+<Validation Validator="@OnValidate">
+  <Field ColumnSize="@ColumnSize">
+    <FieldLabel>@(Label)</FieldLabel>
+    <DateEdit Date="@Date" DateChanged="@DateChanged" @attributes="@AdditionalAttributes">
+      <Feedback>
+        <ValidationError>
+          <ValidationMessage For="@For" />
+        </ValidationError>
+      </Feedback>
+    </DateEdit>
+  </Field>
+</Validation>
+
+@code {
+  /// <summary>
+  /// Gets or sets the label to be associated to the input.
+  /// </summary>
+  [Parameter]
+  public string Label { get; set; }
+
+  /// <summary>
+  /// Gets or sets the value of the DateEdit.
+  /// </summary>
+  [Parameter]
+  public TValue Date { get; set; }
+
+  /// <summary>
+  /// Gets or sets the callback to be called when <see cref="Date"/> changes.
+  /// </summary>
+  [Parameter]
+  public EventCallback<TValue> DateChanged { get; set; }
+
+  /// <summary>
+  /// Gets or sets the optional ColumnSize to associate to the Field.
+  /// </summary>
+  [Parameter]
+  public IFluentColumn ColumnSize { get; set; }
+}

--- a/src/Mandarin.Client/Components/Inputs/ValidatedEditBase.razor
+++ b/src/Mandarin.Client/Components/Inputs/ValidatedEditBase.razor
@@ -1,0 +1,35 @@
+﻿@using System.Linq.Expressions
+@using Bashi.Core.Extensions
+
+@code {
+  /// <summary>
+  /// Gets or sets the expression referencing the field to be validated.
+  /// </summary>
+  [Parameter]
+  public Expression<Func<object>> For { get; set; }
+
+  /// <summary>
+  /// Gets or sets the EditContext of the form that is associated to this TextEdit.
+  /// </summary>
+  [CascadingParameter]
+  public EditContext EditContext { get; set; }
+
+  /// <summary>
+  /// Gets or sets the map of additional parameters to attach to the underlying TextEdit.
+  /// </summary>
+  [Parameter(CaptureUnmatchedValues = true)]
+  public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+  /// <summary>
+  /// Validates the component by forwarding any validation messages in the EditContext for the field
+  /// described by the <see cref="For"/> expression. Any validation messages indicates the field is
+  /// in a failed status.
+  /// </summary>
+  protected void OnValidate(ValidatorEventArgs e)
+  {
+    var messages = EditContext.GetValidationMessages(For).NullToEmpty().AsReadOnlyList();
+    e.Status = messages.Any() ? ValidationStatus.Error : ValidationStatus.Success;
+    e.ErrorText = messages.FirstOrDefault();
+  }
+
+}

--- a/src/Mandarin.Client/Components/Inputs/ValidatedNumericEdit.razor
+++ b/src/Mandarin.Client/Components/Inputs/ValidatedNumericEdit.razor
@@ -1,0 +1,47 @@
+﻿@inherits ValidatedEditBase
+@typeparam TValue
+
+<Validation Validator="@OnValidate">
+  <Field ColumnSize="@ColumnSize">
+    <Addons>
+      <Addon AddonType="AddonType.Start">
+        <AddonLabel>@Label</AddonLabel>
+      </Addon>
+      <Addon AddonType="AddonType.Body">
+        <NumericEdit Value="@Value" ValueChanged="@ValueChanged" @attributes="@AdditionalAttributes">
+          <Feedback>
+            <ValidationError>
+              <ValidationMessage For="@For" />
+            </ValidationError>
+          </Feedback>
+        </NumericEdit>
+      </Addon>
+    </Addons>
+  </Field>
+</Validation>
+
+@code {
+  /// <summary>
+  /// Gets or sets the label to be associated to the input.
+  /// </summary>
+  [Parameter]
+  public string Label { get; set; }
+
+  /// <summary>
+  /// Gets or sets the value of the ValueEdit.
+  /// </summary>
+  [Parameter]
+  public TValue Value { get; set; }
+
+  /// <summary>
+  /// Gets or sets the callback to be called when <see cref="Value"/> changes.
+  /// </summary>
+  [Parameter]
+  public EventCallback<TValue> ValueChanged { get; set; }
+
+  /// <summary>
+  /// Gets or sets the optional ColumnSize to associate to the Field.
+  /// </summary>
+  [Parameter]
+  public IFluentColumn ColumnSize { get; set; }
+}

--- a/src/Mandarin.Client/Components/Inputs/ValidatedSelect.razor
+++ b/src/Mandarin.Client/Components/Inputs/ValidatedSelect.razor
@@ -1,0 +1,59 @@
+﻿@inherits ValidatedEditBase
+@typeparam TValue
+
+<Validation Validator="@OnValidate">
+  <Field>
+    <FieldLabel>@(Label)</FieldLabel>
+    <Select SelectedValue="@SelectedValue" SelectedValueChanged="@SelectedValueChanged">
+      <ChildContent>
+        @foreach (var option in Options)
+        {
+          <SelectItem Value="@option">@(StringFunc(option))</SelectItem>
+        }
+      </ChildContent>
+      <Feedback>
+        <ValidationError>
+          <ValidationMessage For="@For" />
+        </ValidationError>
+      </Feedback>
+    </Select>
+  </Field>
+</Validation>
+
+@code {
+  /// <summary>
+  /// Gets or sets the label to be associated to the input.
+  /// </summary>
+  [Parameter]
+  public string Label { get; set; }
+
+  /// <summary>
+  /// Gets or sets the value of the Select.
+  /// </summary>
+  [Parameter]
+  public TValue SelectedValue { get; set; }
+
+  /// <summary>
+  /// Gets or sets the callback to be called when <see cref="SelectedValue"/> changes.
+  /// </summary>
+  [Parameter]
+  public EventCallback<TValue> SelectedValueChanged { get; set; }
+
+  /// <summary>
+  /// Gets or sets the available options to display for selection.
+  /// </summary>
+  [Parameter]
+  public IReadOnlyCollection<TValue> Options { get; set; }
+
+  /// <summary>
+  /// Gets or sets the function to evaluate for determining a displayable value for each option.
+  /// </summary>
+  [Parameter]
+  public Func<TValue, string> StringFunc { get; set; } = static v => v.ToString();
+
+  /// <summary>
+  /// Gets or sets the optional ColumnSize to associate to the Field.
+  /// </summary>
+  [Parameter]
+  public IFluentColumn ColumnSize { get; set; }
+}

--- a/src/Mandarin.Client/Components/Inputs/ValidatedTextEdit.razor
+++ b/src/Mandarin.Client/Components/Inputs/ValidatedTextEdit.razor
@@ -1,0 +1,40 @@
+﻿@inherits ValidatedEditBase
+
+<Validation Validator="@OnValidate">
+  <Field ColumnSize="@ColumnSize">
+    <FieldLabel>@(Label)</FieldLabel>
+    <TextEdit Text="@Text" TextChanged="@TextChanged" @attributes="@AdditionalAttributes">
+      <Feedback>
+        <ValidationError>
+          <ValidationMessage For="@For" />
+        </ValidationError>
+      </Feedback>
+    </TextEdit>
+  </Field>
+</Validation>
+
+@code {
+  /// <summary>
+  /// Gets or sets the label to be associated to the input.
+  /// </summary>
+  [Parameter]
+  public string Label { get; set; }
+
+  /// <summary>
+  /// Gets or sets the value of the TextEdit.
+  /// </summary>
+  [Parameter]
+  public string Text { get; set; }
+
+  /// <summary>
+  /// Gets or sets the callback to be called when <see cref="Text"/> changes.
+  /// </summary>
+  [Parameter]
+  public EventCallback<string> TextChanged { get; set; }
+
+  /// <summary>
+  /// Gets or sets the optional ColumnSize to associate to the Field.
+  /// </summary>
+  [Parameter]
+  public IFluentColumn ColumnSize { get; set; }
+}

--- a/src/Mandarin.Client/Components/Inputs/ValidatedTextEditWithIcon.razor
+++ b/src/Mandarin.Client/Components/Inputs/ValidatedTextEditWithIcon.razor
@@ -1,0 +1,52 @@
+﻿@inherits ValidatedEditBase
+
+<Validation Validator="@OnValidate">
+  <Field ColumnSize="@ColumnSize">
+    <Addons>
+      <Addon AddonType="@AddonType.Start">
+        <AddonLabel><Icon Class="@Icon.IconClass" Name="@Icon.IconName" IconStyle="@Icon.IconStyle" /></AddonLabel>
+      </Addon>
+      <Addon AddonType="@AddonType.Body">
+        <TextEdit Text="@Text" TextChanged="@TextChanged" Placeholder="@Label" @attributes="@AdditionalAttributes">
+          <Feedback>
+            <ValidationError>
+              <ValidationMessage For="@For" />
+            </ValidationError>
+          </Feedback>
+        </TextEdit>
+      </Addon>
+    </Addons>
+  </Field>
+</Validation>
+
+@code {
+  /// <summary>
+  /// Gets or sets the label to be associated to the input.
+  /// </summary>
+  [Parameter]
+  public string Label { get; set; }
+
+  /// <summary>
+  /// Gets or sets the icon to be associated to the input.
+  /// </summary>
+  [Parameter]
+  public MandarinIcon Icon { get; set; }
+
+  /// <summary>
+  /// Gets or sets the value of the TextEdit.
+  /// </summary>
+  [Parameter]
+  public string Text { get; set; }
+
+  /// <summary>
+  /// Gets or sets the callback to be called when <see cref="Text"/> changes.
+  /// </summary>
+  [Parameter]
+  public EventCallback<string> TextChanged { get; set; }
+
+  /// <summary>
+  /// Gets or sets the optional ColumnSize to associate to the Field.
+  /// </summary>
+  [Parameter]
+  public IFluentColumn ColumnSize { get; set; }
+}

--- a/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
@@ -20,7 +20,7 @@
     }
     else
     {
-      <Validations @ref="validations" Model="@EditContext" ValidateOnLoad="false">
+      <Validations @ref="validations" EditContext="@EditContext" ValidateOnLoad="false">
         <ValidatedTextEdit For="() => Stockist.StockistCode" @bind-Text="@Stockist.StockistCode" Label="Artist Code" Disabled="@(true)"/>
         <Fields>
           <ValidatedTextEdit For="() => Stockist.FirstName" @bind-Text="@Stockist.FirstName" Label="First Name" ColumnSize="@ColumnSize.Is6" />

--- a/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
@@ -1,5 +1,4 @@
 ﻿@page "/artists/edit/{stockistCode}"
-@page "/artists/new"
 @using Bashi.Core.Extensions
 @using Bashi.Core.Utils
 @using Mandarin.Commissions

--- a/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
@@ -1,299 +1,77 @@
 ﻿@page "/artists/edit/{stockistCode}"
 @using Bashi.Core.Extensions
-@using Bashi.Core.Utils
-@using Mandarin.Commissions
+@using Mandarin.Client.Utils
 @using Mandarin.Common
-@using Mandarin.Stockists
-@inject IStockistService StockistService;
-@inject ICommissionService CommissionService;
-@inject NavigationManager NavigationManager;
+@using System.Reactive.Linq
+@inherits ReactiveInjectableComponentBase<IArtistsEditViewModel>
 
-@if (Stockist == null)
-{
-  <Card>
-    <CardHeader>
-      <CardTitle>Artist Details...</CardTitle>
-    </CardHeader>
-    <CardBody>
+<Card>
+  <CardHeader>
+    <CardTitle>Update @(StockistCode)</CardTitle>
+    <CardActions Float="Float.Right">
+      <ReactiveButton ReactiveCommand="@ViewModel!.Save" Color="Color.Primary">Save</ReactiveButton>
+      <ReactiveButton ReactiveCommand="@ViewModel!.Cancel" Color="Color.Danger">Cancel</ReactiveButton>
+    </CardActions>
+  </CardHeader>
+  <CardBody>
+    @if (ViewModel!.IsLoading)
+    {
       <MandarinProgressBar>Fetching Artist...</MandarinProgressBar>
-    </CardBody>
-  </Card>
-}
-else
-{
-  <Card>
-    <CardHeader>
-        <CardTitle>@(isNew ? "New Artist" : $"{Stockist.StockistCode} - {Stockist.Details.DisplayName}")</CardTitle>
-      <CardActions Float="Float.Right">
-        @if (isEditing)
-        {
-          <Button Color="Color.Primary" Clicked="OnSaveClicked">Save</Button>
-          <Button Color="Color.Danger" Clicked="OnCancelClicked">Cancel</Button>
-        }
-        else
-        {
-          <Button Color="Color.Primary" Clicked="@OnCloseClicked">Close</Button>
-          <Button Color="Color.Dark" Clicked="@OnEditClicked">Edit</Button>
-        }
-      </CardActions>
-    </CardHeader>
-    <CardBody>
-      <Validations @ref="validations" Mode="ValidationMode.Auto" Model="@Stockist" ValidateOnLoad="false">
-        <Validation>
-          <Field>
-            <FieldLabel>Artist Code</FieldLabel>
-            <TextEdit @bind-Text="@Stockist.StockistCode" Disabled="@(!isNew)">
-              <Feedback><ValidationError /></Feedback>
-            </TextEdit>
-          </Field>
-        </Validation>
-
+    }
+    else
+    {
+      <Validations @ref="validations" Model="@EditContext" ValidateOnLoad="false">
+        <ValidatedTextEdit For="() => Stockist.StockistCode" @bind-Text="@Stockist.StockistCode" Label="Artist Code" Disabled="@(true)"/>
         <Fields>
-          <Validation>
-            <Field ColumnSize="ColumnSize.Is6">
-              <FieldLabel>First Name</FieldLabel>
-              <TextEdit @bind-Text="@Stockist.Details.FirstName" Disabled="@(!isEditing)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Field>
-          </Validation>
-          <Validation>
-            <Field ColumnSize="ColumnSize.Is6">
-              <FieldLabel>Last Name</FieldLabel>
-              <TextEdit @bind-Text="@Stockist.Details.LastName" Disabled="@(!isEditing)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Field>
-          </Validation>
+          <ValidatedTextEdit For="() => Stockist.FirstName" @bind-Text="@Stockist.FirstName" Label="First Name" ColumnSize="@ColumnSize.Is6" />
+          <ValidatedTextEdit For="() => Stockist.LastName" @bind-Text="@Stockist.LastName" Label="Last Name" ColumnSize="@ColumnSize.Is6" />
         </Fields>
-
-        <Validation>
-          <Field>
-            <FieldLabel>Full/Display Name</FieldLabel>
-            <TextEdit @bind-Text="@Stockist.Details.DisplayName" Disabled="@(!isEditing)">
-              <Feedback><ValidationError /></Feedback>
-            </TextEdit>
-          </Field>
-        </Validation>
-
-        <Validation>
-          <Field>
-            <FieldLabel>Email Address</FieldLabel>
-            <TextEdit Role="@TextRole.Email" @bind-Text="@Stockist.Details.EmailAddress" Disabled="@(!isEditing)">
-              <Feedback><ValidationError /></Feedback>
-            </TextEdit>
-          </Field>
-        </Validation>
-
-        <Validation>
-          <Field>
-            <FieldLabel>Status</FieldLabel>
-            <Select TValue="StatusMode" @bind-SelectedValue="@Stockist.StatusCode" Disabled="@(!isEditing)">
-              <ChildContent>
-                @foreach (var status in EnumUtil.GetValues<StatusMode>().Except(new[] { StatusMode.Unknown }))
-                {
-                  <SelectItem Value="@status">@(status.GetDescription())</SelectItem>
-                }
-              </ChildContent>
-              <Feedback><ValidationError /></Feedback>
-            </Select>
-          </Field>
-        </Validation>
-
+        <ValidatedTextEdit For="() => Stockist.DisplayName" @bind-Text="@Stockist.DisplayName" Label="Full/Display Name" />
+        <ValidatedTextEdit For="() => Stockist.EmailAddress" @bind-Text="@Stockist.EmailAddress" Label="Email Address" />
+        <ValidatedSelect For="() => Stockist.StatusCode" @bind-SelectedValue="@Stockist.StatusCode" Label="Status" Options="@ViewModel!.Statuses" StringFunc="@(s => s.GetDescription())"/>
         <Divider />
 
         <FieldLabel>Artist Social Media</FieldLabel>
-
-        <Validation>
-          <Field>
-            <Addons>
-              <Addon AddonType="AddonType.Start">
-                <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-twitter")" /></AddonLabel>
-              </Addon>
-              <Addon AddonType="AddonType.Body">
-                <TextEdit @bind-Text="@Stockist.Details.TwitterHandle" Placeholder="Twitter Handle" Disabled="@(!StockistIsDisplayed || !isEditing)">
-                  <Feedback><ValidationError /></Feedback>
-                </TextEdit>
-              </Addon>
-            </Addons>
-          </Field>
-        </Validation>
-        <Validation>
-          <Field>
-            <Addons>
-              <Addon AddonType="AddonType.Start">
-                <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-facebook")" /></AddonLabel>
-              </Addon>
-              <Addon AddonType="AddonType.Body">
-                <TextEdit @bind-Text="@Stockist.Details.FacebookHandle" Placeholder="Facebook Handle" Disabled="@(!StockistIsDisplayed || !isEditing)">
-                  <Feedback><ValidationError /></Feedback>
-                </TextEdit>
-              </Addon>
-            </Addons>
-          </Field>
-        </Validation>
-        <Validation>
-          <Field>
-            <Addons>
-              <Addon AddonType="AddonType.Start">
-                <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-instagram")" /></AddonLabel>
-              </Addon>
-              <Addon AddonType="AddonType.Body">
-                <TextEdit @bind-Text="@Stockist.Details.InstagramHandle" Placeholder="Instagram Handle" Disabled="@(!StockistIsDisplayed || !isEditing)">
-                  <Feedback><ValidationError /></Feedback>
-                </TextEdit>
-              </Addon>
-            </Addons>
-          </Field>
-        </Validation>
-        <Validation>
-          <Field>
-            <Addons>
-              <Addon AddonType="AddonType.Start">
-                <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-tumblr")" /></AddonLabel>
-              </Addon>
-              <Addon AddonType="AddonType.Body">
-                <TextEdit @bind-Text="@Stockist.Details.TumblrHandle" Placeholder="Tumblr Handle" Disabled="@(!StockistIsDisplayed || !isEditing)">
-                  <Feedback><ValidationError /></Feedback>
-                </TextEdit>
-              </Addon>
-            </Addons>
-          </Field>
-        </Validation>
-        <Validation>
-          <Field>
-            <Addons>
-              <Addon AddonType="AddonType.Start">
-                <AddonLabel><Icon Name="Blazorise.Icons.FontAwesome.FontAwesomeIcons.GlobeEurope" /></AddonLabel>
-              </Addon>
-              <Addon AddonType="AddonType.Body">
-                <TextEdit @bind-Text="@Stockist.Details.WebsiteUrl" Placeholder="Personal Website" Disabled="@(!StockistIsDisplayed || !isEditing)">
-                  <Feedback><ValidationError /></Feedback>
-                </TextEdit>
-              </Addon>
-            </Addons>
-          </Field>
-        </Validation>
-
+        <ValidatedTextEditWithIcon For="() => Stockist.TwitterHandle" @bind-Text="@Stockist.TwitterHandle" Label="Twitter Handle" Icon="@MandarinIcon.Twitter" Disabled="@(!StockistIsDisplayed)" />
+        <ValidatedTextEditWithIcon For="() => Stockist.FacebookHandle" @bind-Text="@Stockist.FacebookHandle" Label="Facebook Handle" Icon="@MandarinIcon.Facebook" Disabled="@(!StockistIsDisplayed)" />
+        <ValidatedTextEditWithIcon For="() => Stockist.InstagramHandle" @bind-Text="@Stockist.InstagramHandle" Label="Instagram Handle" Icon="@MandarinIcon.Instagram" Disabled="@(!StockistIsDisplayed)" />
+        <ValidatedTextEditWithIcon For="() => Stockist.TumblrHandle" @bind-Text="@Stockist.TumblrHandle" Label="Tumblr Handle" Icon="@MandarinIcon.Tumblr" Disabled="@(!StockistIsDisplayed)" />
+        <ValidatedTextEditWithIcon For="() => Stockist.WebsiteUrl" @bind-Text="@Stockist.WebsiteUrl" Label="Personal Website" Icon="@MandarinIcon.Url" Disabled="@(!StockistIsDisplayed)" />
         <Divider />
 
         <FieldLabel>Commission</FieldLabel>
-        <Validation>
-          <Field>
-            <Addons>
-              <Addon AddonType="AddonType.Start">
-                <AddonLabel>%</AddonLabel>
-              </Addon>
-              <Addon AddonType="AddonType.Body">
-                <NumericEdit Min="0" Max="100" @bind-Value="@Commission.Rate" Disabled="@(!isEditing)">
-                  <Feedback><ValidationError /></Feedback>
-                </NumericEdit>
-              </Addon>
-            </Addons>
-          </Field>
-        </Validation>
-        <Validation>
-          <Fields>
-            <Field ColumnSize="ColumnSize.Is6">
-              <FieldLabel>Start Date</FieldLabel>
-              <DateEdit TValue="DateTime" @bind-Date="@Commission.StartDate" Disabled="@(!isEditing)" />
-            </Field>
-            <Field ColumnSize="ColumnSize.Is6">
-              <FieldLabel>End Date</FieldLabel>
-              <DateEdit TValue="DateTime" @bind-Date="@Commission.EndDate" Disabled="@(!isEditing)" />
-            </Field>
-          </Fields>
-        </Validation>
+        <ValidatedNumericEdit For="() => Stockist.Rate" @bind-Value="@Stockist.Rate" Label="%" Min="@(0)" Max="@(100)" />
+        <Fields>
+          <ValidatedDateEdit For="() => Stockist.StartDate" @bind-Date="@Stockist.StartDate" Label="Start Date" ColumnSize="ColumnSize.Is6" />
+          <ValidatedDateEdit For="() => Stockist.EndDate" @bind-Date="@Stockist.EndDate" Label="End Date" ColumnSize="ColumnSize.Is6" />
+        </Fields>
       </Validations>
-    </CardBody>
-  </Card>
-}
+    }
+  </CardBody>
+</Card>
 
 @code
 {
+  private Validations validations;
+
   /// <summary>
   /// Gets or sets the stockist code to be inspected.
   /// </summary>
   [Parameter]
   public string StockistCode { get; set; }
 
-  private Stockist Stockist { get; set; }
-  private Commission Commission => Stockist.Commission;
+  private EditContext EditContext { get; set; }
+  private IArtistViewModel Stockist => ViewModel!.Stockist;
   private bool StockistIsDisplayed => Stockist.StatusCode == StatusMode.Active;
 
-  private Validations validations;
-  private bool isNew;
-  private bool isEditing;
-
   /// <inheritdoc />
-  protected override async Task OnInitializedAsync()
+  protected override async Task OnParametersSetAsync()
   {
-    await base.OnInitializedAsync();
+    await base.OnParametersSetAsync();
+    await ViewModel!.LoadData.Execute(StockistCode);
 
-    if (string.IsNullOrEmpty(StockistCode))
-    {
-      this.isNew = true;
-      this.isEditing = true;
-      this.Stockist = new Stockist
-      {
-        StatusCode = StatusMode.Active,
-        Details = new StockistDetail(),
-      };
-      Stockist.Commission = new Commission
-      {
-        Rate = 100,
-        StartDate = DateTime.Now.Date,
-        EndDate = DateTime.Now.AddDays(90).Date,
-      };
-    }
-    else
-    {
-      this.isNew = false;
-      this.isEditing = false;
-      this.Stockist = await StockistService.GetStockistByCodeAsync(StockistCode);
-    }
-  }
-
-  private void OnEditClicked()
-  {
-    this.isNew = false;
-    this.isEditing = true;
-    validations.ClearAll();
-  }
-
-  private async Task OnSaveClicked()
-  {
-    if (!validations.ValidateAll())
-    {
-      return;
-    }
-
-    await StockistService.SaveStockistAsync(this.Stockist);
-    NavigationManager.NavigateTo($"/artists/edit/{this.Stockist.StockistCode}");
-    validations.ClearAll();
-    validations.ClearAll();
-    isNew = false;
-    isEditing = false;
-    StateHasChanged();
-  }
-
-  private async Task OnCancelClicked()
-  {
-    this.isEditing = false;
-
-    if (isNew)
-    {
-      OnCloseClicked();
-    }
-    else
-    {
-      this.Stockist = await StockistService.GetStockistByCodeAsync(this.StockistCode);
-    }
-  }
-
-  private void OnCloseClicked()
-  {
-    NavigationManager.NavigateTo("/artists");
+    this.EditContext = new EditContext(Stockist);
+    this.EditContext.SubscribeToViewModel(ViewModel, () => validations.ValidateAll());
   }
 
 }

--- a/src/Mandarin.Client/Pages/Artists/ArtistsIndex.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsIndex.razor
@@ -1,28 +1,30 @@
 ﻿@page "/artists"
 @using Bashi.Core.Extensions
-@using Mandarin.Stockists
-@inject IStockistService stockistService;
-@inject NavigationManager navigationManager;
+@using System.Reactive.Linq
+@inherits ReactiveInjectableComponentBase<IArtistsIndexViewModel>
 
 <Card>
   <CardHeader>
     <CardTitle>All Artists</CardTitle>
     <CardActions Float="Float.Right">
-      <Button Color="Color.Primary" Clicked="@OnNewClicked">New</Button>
+      <ReactiveButton ReactiveCommand="@ViewModel!.EditSelected" Color="Color.Secondary">Edit</ReactiveButton>
+      <ReactiveButton ReactiveCommand="@ViewModel!.CreateNew" Color="Color.Primary">New</ReactiveButton>
     </CardActions>
   </CardHeader>
   <CardBody>
-    @if (data == null)
+    @if (ViewModel!.IsLoading)
     {
       <MandarinProgressBar>Fetching artists...</MandarinProgressBar>
     }
     else
     {
-      <DataGrid TItem="Stockist" Data="@data" Filterable="true" ShowPager="true" PageSize="10" Striped="true" Responsive="true"
-                SelectedRowChanged="@OnStockistSelected">
-        <DataGridColumn TItem="Stockist" Field="StockistCode" Caption="Code" Width="75px" />
-        <DataGridColumn TItem="Stockist" Field="Details.DisplayName" Caption="Name" TextAlignment="TextAlignment.Right" />
-        <DataGridColumn TItem="Stockist" Field="StatusCode" Caption="Status" TextAlignment="TextAlignment.Right">
+      <DataGrid TItem="IArtistViewModel" Data="@ViewModel!.Rows" Filterable="true" Striped="true"
+                ShowPager="true" PagerPosition="DataGridPagerPosition.Top" PageSize="10"
+                Responsive="true"
+                RowSelectable="@(_ => true)" @bind-SelectedRow="@ViewModel!.SelectedRow">
+        <DataGridColumn TItem="IArtistViewModel" Field="StockistCode" Caption="Code" Width="75px" />
+        <DataGridColumn TItem="IArtistViewModel" Field="DisplayName" Caption="Name" TextAlignment="TextAlignment.Right" />
+        <DataGridColumn TItem="IArtistViewModel" Field="StatusCode" Caption="Status" TextAlignment="TextAlignment.Right">
           <DisplayTemplate>@context.StatusCode.GetDescription()</DisplayTemplate>
         </DataGridColumn>
       </DataGrid>
@@ -30,25 +32,13 @@
   </CardBody>
 </Card>
 
-@code
-{
-  private IReadOnlyList<Stockist> data;
+@code {
 
   /// <inheritdoc />
   protected override async Task OnInitializedAsync()
   {
     await base.OnInitializedAsync();
-
-    data = await stockistService.GetStockistsAsync();
+    await ViewModel!.LoadData.Execute();
   }
 
-  private void OnNewClicked()
-  {
-    navigationManager.NavigateTo("/artists/new");
-  }
-
-  private void OnStockistSelected(Stockist selectedStockist)
-  {
-    navigationManager.NavigateTo($"/artists/edit/{selectedStockist.StockistCode}");
-  }
 }

--- a/src/Mandarin.Client/Pages/Artists/ArtistsNew.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsNew.razor
@@ -14,7 +14,7 @@
   </CardHeader>
   <CardBody>
     <Validations @ref="@validations" EditContext="@EditContext" ValidateOnLoad="false">
-      <ValidatedTextEdit For="() => Stockist.StockistCode" @bind-Text="@Stockist.StockistCode" Label="Artist Name" />
+      <ValidatedTextEdit For="() => Stockist.StockistCode" @bind-Text="@Stockist.StockistCode" Label="Artist Code" />
       <Fields>
         <ValidatedTextEdit For="() => Stockist.FirstName" @bind-Text="@Stockist.FirstName" Label="First Name" ColumnSize="@ColumnSize.Is6" />
         <ValidatedTextEdit For="() => Stockist.LastName" @bind-Text="@Stockist.LastName" Label="Last Name" ColumnSize="@ColumnSize.Is6" />
@@ -35,8 +35,8 @@
       <FieldLabel>Commission</FieldLabel>
       <ValidatedNumericEdit For="() => Stockist.Rate" @bind-Value="@Stockist.Rate" Label="%" Min="@(0)" Max="@(100)" />
       <Fields>
-        <ValidatedDateEdit For="() => Stockist.StartDate" @bind-Date="@Stockist.StartDate" ColumnSize="ColumnSize.Is6" />
-        <ValidatedDateEdit For="() => Stockist.EndDate" @bind-Date="@Stockist.EndDate" ColumnSize="ColumnSize.Is6" />
+        <ValidatedDateEdit For="() => Stockist.StartDate" @bind-Date="@Stockist.StartDate" Label="Start Date" ColumnSize="ColumnSize.Is6" />
+        <ValidatedDateEdit For="() => Stockist.EndDate" @bind-Date="@Stockist.EndDate" Label="End Date" ColumnSize="ColumnSize.Is6" />
       </Fields>
     </Validations>
   </CardBody>

--- a/src/Mandarin.Client/Pages/Artists/ArtistsNew.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsNew.razor
@@ -1,0 +1,194 @@
+﻿@page "/artists/new"
+@using Bashi.Core.Extensions
+@using Mandarin.Common
+@inherits ReactiveInjectableComponentBase<IArtistsNewViewModel>
+
+<Card>
+  <CardHeader>
+    <CardTitle>"New Artist"</CardTitle>
+    <CardActions Float="Float.Right">
+      <ReactiveButton ReactiveCommand="@ViewModel!.Save" Color="Color.Primary">Save</ReactiveButton>
+      <ReactiveButton ReactiveCommand="@ViewModel!.Cancel" Color="Color.Danger">Cancel</ReactiveButton>
+    </CardActions>
+  </CardHeader>
+  <CardBody>
+    <Validations Mode="ValidationMode.Auto" Model="@Stockist" ValidateOnLoad="false">
+      <Validation>
+        <Field>
+          <FieldLabel>Artist Code</FieldLabel>
+          <TextEdit @bind-Text="@Stockist.StockistCode">
+            <Feedback><ValidationError /></Feedback>
+          </TextEdit>
+        </Field>
+      </Validation>
+
+      <Fields>
+        <Validation>
+          <Field ColumnSize="ColumnSize.Is6">
+            <FieldLabel>First Name</FieldLabel>
+            <TextEdit @bind-Text="@Stockist.FirstName">
+              <Feedback><ValidationError /></Feedback>
+            </TextEdit>
+          </Field>
+        </Validation>
+        <Validation>
+          <Field ColumnSize="ColumnSize.Is6">
+            <FieldLabel>Last Name</FieldLabel>
+            <TextEdit @bind-Text="@Stockist.LastName">
+              <Feedback><ValidationError /></Feedback>
+            </TextEdit>
+          </Field>
+        </Validation>
+      </Fields>
+
+      <Validation>
+        <Field>
+          <FieldLabel>Full/Display Name</FieldLabel>
+          <TextEdit @bind-Text="@Stockist.DisplayName">
+            <Feedback><ValidationError /></Feedback>
+          </TextEdit>
+        </Field>
+      </Validation>
+
+      <Validation>
+        <Field>
+          <FieldLabel>Email Address</FieldLabel>
+          <TextEdit Role="@TextRole.Email" @bind-Text="@Stockist.EmailAddress">
+            <Feedback><ValidationError /></Feedback>
+          </TextEdit>
+        </Field>
+      </Validation>
+
+      <Validation>
+        <Field>
+          <FieldLabel>Status</FieldLabel>
+          <Select TValue="StatusMode" @bind-SelectedValue="@Stockist.StatusCode">
+            <ChildContent>
+              @foreach (var status in ViewModel!.Statuses)
+              {
+                <SelectItem Value="@status">@(status.GetDescription())</SelectItem>
+              }
+            </ChildContent>
+            <Feedback><ValidationError /></Feedback>
+          </Select>
+        </Field>
+      </Validation>
+
+      <Divider />
+
+      <FieldLabel>Artist Social Media</FieldLabel>
+
+      <Validation>
+        <Field>
+          <Addons>
+            <Addon AddonType="AddonType.Start">
+              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-twitter")" /></AddonLabel>
+            </Addon>
+            <Addon AddonType="AddonType.Body">
+              <TextEdit @bind-Text="@Stockist.TwitterHandle" Placeholder="Twitter Handle" Disabled="@(!StockistIsDisplayed)">
+                <Feedback><ValidationError /></Feedback>
+              </TextEdit>
+            </Addon>
+          </Addons>
+        </Field>
+      </Validation>
+      <Validation>
+        <Field>
+          <Addons>
+            <Addon AddonType="AddonType.Start">
+              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-facebook")" /></AddonLabel>
+            </Addon>
+            <Addon AddonType="AddonType.Body">
+              <TextEdit @bind-Text="@Stockist.FacebookHandle" Placeholder="Facebook Handle" Disabled="@(!StockistIsDisplayed)">
+                <Feedback><ValidationError /></Feedback>
+              </TextEdit>
+            </Addon>
+          </Addons>
+        </Field>
+      </Validation>
+      <Validation>
+        <Field>
+          <Addons>
+            <Addon AddonType="AddonType.Start">
+              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-instagram")" /></AddonLabel>
+            </Addon>
+            <Addon AddonType="AddonType.Body">
+              <TextEdit @bind-Text="@Stockist.InstagramHandle" Placeholder="Instagram Handle" Disabled="@(!StockistIsDisplayed)">
+                <Feedback><ValidationError /></Feedback>
+              </TextEdit>
+            </Addon>
+          </Addons>
+        </Field>
+      </Validation>
+      <Validation>
+        <Field>
+          <Addons>
+            <Addon AddonType="AddonType.Start">
+              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-tumblr")" /></AddonLabel>
+            </Addon>
+            <Addon AddonType="AddonType.Body">
+              <TextEdit @bind-Text="@Stockist.TumblrHandle" Placeholder="Tumblr Handle" Disabled="@(!StockistIsDisplayed)">
+                <Feedback><ValidationError /></Feedback>
+              </TextEdit>
+            </Addon>
+          </Addons>
+        </Field>
+      </Validation>
+      <Validation>
+        <Field>
+          <Addons>
+            <Addon AddonType="AddonType.Start">
+              <AddonLabel><Icon Name="Blazorise.Icons.FontAwesome.FontAwesomeIcons.GlobeEurope" /></AddonLabel>
+            </Addon>
+            <Addon AddonType="AddonType.Body">
+              <TextEdit @bind-Text="@Stockist.WebsiteUrl" Placeholder="Personal Website" Disabled="@(!StockistIsDisplayed)">
+                <Feedback><ValidationError /></Feedback>
+              </TextEdit>
+            </Addon>
+          </Addons>
+        </Field>
+      </Validation>
+
+      <Divider />
+
+      <FieldLabel>Commission</FieldLabel>
+      <Validation>
+        <Field>
+          <Addons>
+            <Addon AddonType="AddonType.Start">
+              <AddonLabel>%</AddonLabel>
+            </Addon>
+            <Addon AddonType="AddonType.Body">
+              <NumericEdit Min="0" Max="100" @bind-Value="@Stockist.Rate">
+                <Feedback><ValidationError /></Feedback>
+              </NumericEdit>
+            </Addon>
+          </Addons>
+        </Field>
+      </Validation>
+      <Validation>
+        <Fields>
+          <Field ColumnSize="ColumnSize.Is6">
+            <FieldLabel>Start Date</FieldLabel>
+            <DateEdit TValue="DateTime" @bind-Date="@Stockist.StartDate">
+              <Feedback><ValidationError /></Feedback>
+            </DateEdit>
+          </Field>
+          <Field ColumnSize="ColumnSize.Is6">
+            <FieldLabel>End Date</FieldLabel>
+            <DateEdit TValue="DateTime" @bind-Date="@Stockist.EndDate">
+              <Feedback><ValidationError /></Feedback>
+            </DateEdit>
+          </Field>
+        </Fields>
+      </Validation>
+    </Validations>
+  </CardBody>
+</Card>
+
+@code {
+
+  private IArtistViewModel Stockist => ViewModel!.Stockist;
+  private bool StockistIsDisplayed => Stockist.StatusCode == StatusMode.Active;
+
+}

--- a/src/Mandarin.Client/Pages/Artists/ArtistsNew.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsNew.razor
@@ -1,194 +1,62 @@
 ﻿@page "/artists/new"
 @using Bashi.Core.Extensions
 @using Mandarin.Common
+@using Mandarin.Client.Utils
 @inherits ReactiveInjectableComponentBase<IArtistsNewViewModel>
 
 <Card>
   <CardHeader>
-    <CardTitle>"New Artist"</CardTitle>
+    <CardTitle>New Artist</CardTitle>
     <CardActions Float="Float.Right">
-      <ReactiveButton ReactiveCommand="@ViewModel!.Save" Color="Color.Primary">Save</ReactiveButton>
-      <ReactiveButton ReactiveCommand="@ViewModel!.Cancel" Color="Color.Danger">Cancel</ReactiveButton>
+      <ReactiveButton ReactiveCommand="@ViewModel!.Save" Color="@Color.Primary">Save</ReactiveButton>
+      <ReactiveButton ReactiveCommand="@ViewModel!.Cancel" Color="@Color.Danger">Cancel</ReactiveButton>
     </CardActions>
   </CardHeader>
   <CardBody>
-    <Validations Mode="ValidationMode.Auto" Model="@Stockist" ValidateOnLoad="false">
-      <Validation>
-        <Field>
-          <FieldLabel>Artist Code</FieldLabel>
-          <TextEdit @bind-Text="@Stockist.StockistCode">
-            <Feedback><ValidationError /></Feedback>
-          </TextEdit>
-        </Field>
-      </Validation>
-
+    <Validations @ref="@validations" EditContext="@EditContext" ValidateOnLoad="false">
+      <ValidatedTextEdit For="() => Stockist.StockistCode" @bind-Text="@Stockist.StockistCode" Label="Artist Name" />
       <Fields>
-        <Validation>
-          <Field ColumnSize="ColumnSize.Is6">
-            <FieldLabel>First Name</FieldLabel>
-            <TextEdit @bind-Text="@Stockist.FirstName">
-              <Feedback><ValidationError /></Feedback>
-            </TextEdit>
-          </Field>
-        </Validation>
-        <Validation>
-          <Field ColumnSize="ColumnSize.Is6">
-            <FieldLabel>Last Name</FieldLabel>
-            <TextEdit @bind-Text="@Stockist.LastName">
-              <Feedback><ValidationError /></Feedback>
-            </TextEdit>
-          </Field>
-        </Validation>
+        <ValidatedTextEdit For="() => Stockist.FirstName" @bind-Text="@Stockist.FirstName" Label="First Name" ColumnSize="@ColumnSize.Is6" />
+        <ValidatedTextEdit For="() => Stockist.LastName" @bind-Text="@Stockist.LastName" Label="Last Name" ColumnSize="@ColumnSize.Is6" />
       </Fields>
-
-      <Validation>
-        <Field>
-          <FieldLabel>Full/Display Name</FieldLabel>
-          <TextEdit @bind-Text="@Stockist.DisplayName">
-            <Feedback><ValidationError /></Feedback>
-          </TextEdit>
-        </Field>
-      </Validation>
-
-      <Validation>
-        <Field>
-          <FieldLabel>Email Address</FieldLabel>
-          <TextEdit Role="@TextRole.Email" @bind-Text="@Stockist.EmailAddress">
-            <Feedback><ValidationError /></Feedback>
-          </TextEdit>
-        </Field>
-      </Validation>
-
-      <Validation>
-        <Field>
-          <FieldLabel>Status</FieldLabel>
-          <Select TValue="StatusMode" @bind-SelectedValue="@Stockist.StatusCode">
-            <ChildContent>
-              @foreach (var status in ViewModel!.Statuses)
-              {
-                <SelectItem Value="@status">@(status.GetDescription())</SelectItem>
-              }
-            </ChildContent>
-            <Feedback><ValidationError /></Feedback>
-          </Select>
-        </Field>
-      </Validation>
-
+      <ValidatedTextEdit For="() => Stockist.DisplayName" @bind-Text="@Stockist.DisplayName" Label="Full/Display Name" />
+      <ValidatedTextEdit For="() => Stockist.EmailAddress" @bind-Text="@Stockist.EmailAddress" Label="Email Address" />
+      <ValidatedSelect For="() => Stockist.StatusCode" @bind-SelectedValue="@Stockist.StatusCode" Label="Status" Options="@ViewModel!.Statuses" StringFunc="@(s => s.GetDescription())"/>
       <Divider />
 
       <FieldLabel>Artist Social Media</FieldLabel>
-
-      <Validation>
-        <Field>
-          <Addons>
-            <Addon AddonType="AddonType.Start">
-              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-twitter")" /></AddonLabel>
-            </Addon>
-            <Addon AddonType="AddonType.Body">
-              <TextEdit @bind-Text="@Stockist.TwitterHandle" Placeholder="Twitter Handle" Disabled="@(!StockistIsDisplayed)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Addon>
-          </Addons>
-        </Field>
-      </Validation>
-      <Validation>
-        <Field>
-          <Addons>
-            <Addon AddonType="AddonType.Start">
-              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-facebook")" /></AddonLabel>
-            </Addon>
-            <Addon AddonType="AddonType.Body">
-              <TextEdit @bind-Text="@Stockist.FacebookHandle" Placeholder="Facebook Handle" Disabled="@(!StockistIsDisplayed)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Addon>
-          </Addons>
-        </Field>
-      </Validation>
-      <Validation>
-        <Field>
-          <Addons>
-            <Addon AddonType="AddonType.Start">
-              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-instagram")" /></AddonLabel>
-            </Addon>
-            <Addon AddonType="AddonType.Body">
-              <TextEdit @bind-Text="@Stockist.InstagramHandle" Placeholder="Instagram Handle" Disabled="@(!StockistIsDisplayed)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Addon>
-          </Addons>
-        </Field>
-      </Validation>
-      <Validation>
-        <Field>
-          <Addons>
-            <Addon AddonType="AddonType.Start">
-              <AddonLabel><Icon IconStyle="IconStyle.Light" Class="fab" Name="@("fa-tumblr")" /></AddonLabel>
-            </Addon>
-            <Addon AddonType="AddonType.Body">
-              <TextEdit @bind-Text="@Stockist.TumblrHandle" Placeholder="Tumblr Handle" Disabled="@(!StockistIsDisplayed)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Addon>
-          </Addons>
-        </Field>
-      </Validation>
-      <Validation>
-        <Field>
-          <Addons>
-            <Addon AddonType="AddonType.Start">
-              <AddonLabel><Icon Name="Blazorise.Icons.FontAwesome.FontAwesomeIcons.GlobeEurope" /></AddonLabel>
-            </Addon>
-            <Addon AddonType="AddonType.Body">
-              <TextEdit @bind-Text="@Stockist.WebsiteUrl" Placeholder="Personal Website" Disabled="@(!StockistIsDisplayed)">
-                <Feedback><ValidationError /></Feedback>
-              </TextEdit>
-            </Addon>
-          </Addons>
-        </Field>
-      </Validation>
-
+      <ValidatedTextEditWithIcon For="() => Stockist.TwitterHandle" @bind-Text="@Stockist.TwitterHandle" Label="Twitter Handle" Icon="@MandarinIcon.Twitter" Disabled="@(!StockistIsDisplayed)" />
+      <ValidatedTextEditWithIcon For="() => Stockist.FacebookHandle" @bind-Text="@Stockist.FacebookHandle" Label="Facebook Handle" Icon="@MandarinIcon.Facebook" Disabled="@(!StockistIsDisplayed)" />
+      <ValidatedTextEditWithIcon For="() => Stockist.InstagramHandle" @bind-Text="@Stockist.InstagramHandle" Label="Instagram Handle" Icon="@MandarinIcon.Instagram" Disabled="@(!StockistIsDisplayed)" />
+      <ValidatedTextEditWithIcon For="() => Stockist.TumblrHandle" @bind-Text="@Stockist.TumblrHandle" Label="Tumblr Handle" Icon="@MandarinIcon.Tumblr" Disabled="@(!StockistIsDisplayed)" />
+      <ValidatedTextEditWithIcon For="() => Stockist.WebsiteUrl" @bind-Text="@Stockist.WebsiteUrl" Label="Personal Website" Icon="@MandarinIcon.Url" Disabled="@(!StockistIsDisplayed)" />
       <Divider />
 
       <FieldLabel>Commission</FieldLabel>
-      <Validation>
-        <Field>
-          <Addons>
-            <Addon AddonType="AddonType.Start">
-              <AddonLabel>%</AddonLabel>
-            </Addon>
-            <Addon AddonType="AddonType.Body">
-              <NumericEdit Min="0" Max="100" @bind-Value="@Stockist.Rate">
-                <Feedback><ValidationError /></Feedback>
-              </NumericEdit>
-            </Addon>
-          </Addons>
-        </Field>
-      </Validation>
-      <Validation>
-        <Fields>
-          <Field ColumnSize="ColumnSize.Is6">
-            <FieldLabel>Start Date</FieldLabel>
-            <DateEdit TValue="DateTime" @bind-Date="@Stockist.StartDate">
-              <Feedback><ValidationError /></Feedback>
-            </DateEdit>
-          </Field>
-          <Field ColumnSize="ColumnSize.Is6">
-            <FieldLabel>End Date</FieldLabel>
-            <DateEdit TValue="DateTime" @bind-Date="@Stockist.EndDate">
-              <Feedback><ValidationError /></Feedback>
-            </DateEdit>
-          </Field>
-        </Fields>
-      </Validation>
+      <ValidatedNumericEdit For="() => Stockist.Rate" @bind-Value="@Stockist.Rate" Label="%" Min="@(0)" Max="@(100)" />
+      <Fields>
+        <ValidatedDateEdit For="() => Stockist.StartDate" @bind-Date="@Stockist.StartDate" ColumnSize="ColumnSize.Is6" />
+        <ValidatedDateEdit For="() => Stockist.EndDate" @bind-Date="@Stockist.EndDate" ColumnSize="ColumnSize.Is6" />
+      </Fields>
     </Validations>
   </CardBody>
 </Card>
 
 @code {
 
+  private Validations validations;
+
+  private EditContext EditContext { get; set; }
   private IArtistViewModel Stockist => ViewModel!.Stockist;
   private bool StockistIsDisplayed => Stockist.StatusCode == StatusMode.Active;
+
+  /// <inheritdoc />
+  protected override void OnInitialized()
+  {
+    base.OnInitialized();
+
+    this.EditContext = new EditContext(Stockist);
+    this.EditContext.SubscribeToViewModel(ViewModel, () => validations.ValidateAll());
+  }
 
 }

--- a/src/Mandarin.Client/Utils/EditContextExtensions.cs
+++ b/src/Mandarin.Client/Utils/EditContextExtensions.cs
@@ -23,7 +23,7 @@ namespace Mandarin.Client.Utils
         public static IDisposable SubscribeToViewModel(this EditContext editContext, IValidatableViewModel viewModel, Action callback)
         {
             var messages = new ValidationMessageStore(editContext);
-            return viewModel.WhenAnyValue(x => x.ValidationResult).Subscribe(HandleValidationResult);
+            return viewModel.WhenAnyValue(x => x.ValidationResult).WhereNotNull().Subscribe(HandleValidationResult);
 
             void HandleValidationResult(ValidationResult validationResult)
             {

--- a/src/Mandarin.Client/Utils/EditContextExtensions.cs
+++ b/src/Mandarin.Client/Utils/EditContextExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using FluentValidation.Results;
+using Mandarin.Client.ViewModels;
+using Microsoft.AspNetCore.Components.Forms;
+using ReactiveUI;
+
+namespace Mandarin.Client.Utils
+{
+    /// <summary>
+    /// Provides extensions on <see cref="EditContext"/> to apply a <see cref="ValidationResult"/> that
+    /// has already been created.
+    /// </summary>
+    internal static class EditContextExtensions
+    {
+        /// <summary>
+        /// Connects updates to the <see cref="ValidationResult"/> on <see cref="IValidatableViewModel"/> to the
+        /// provided <see cref="EditContext"/>. This does not trigger validation to occur.
+        /// </summary>
+        /// <param name="editContext">The EditContext to attach to.</param>
+        /// <param name="viewModel">The ViewModel to be attached to the EditContext.</param>
+        /// <param name="callback">A callback to notify after the validation state is updated.</param>
+        /// <returns><see cref="IDisposable" /> object used to unsubscribe from the observable sequence.</returns>
+        public static IDisposable SubscribeToViewModel(this EditContext editContext, IValidatableViewModel viewModel, Action callback)
+        {
+            var messages = new ValidationMessageStore(editContext);
+            return viewModel.WhenAnyValue(x => x.ValidationResult).Subscribe(HandleValidationResult);
+
+            void HandleValidationResult(ValidationResult validationResult)
+            {
+                messages.Clear();
+                foreach (var error in validationResult.Errors)
+                {
+                    messages.Add(new FieldIdentifier(editContext.Model, error.PropertyName), error.ErrorMessage);
+                }
+
+                editContext.NotifyValidationStateChanged();
+                callback?.Invoke();
+            }
+        }
+    }
+}

--- a/src/Mandarin.Client/_Imports.razor
+++ b/src/Mandarin.Client/_Imports.razor
@@ -14,6 +14,7 @@
 @using Blazorise.DataGrid
 @using Mandarin.Client
 @using Mandarin.Client.Components.Animations;
+@using Mandarin.Client.Components.Inputs;
 @using Mandarin.Client.Components.Layouts;
 @using Mandarin.Client.Components.Reactive;
 @using Mandarin.Client.ViewModels.Index;

--- a/src/Mandarin.Client/_Imports.razor
+++ b/src/Mandarin.Client/_Imports.razor
@@ -17,5 +17,6 @@
 @using Mandarin.Client.Components.Layouts;
 @using Mandarin.Client.Components.Reactive;
 @using Mandarin.Client.ViewModels.Index;
+@using Mandarin.Client.ViewModels.Artists;
 @using Mandarin.Client.ViewModels.Inventory.FramePrices;
 @using ReactiveUI.Blazor;

--- a/src/Mandarin.Interfaces/Stockists/Stockist.cs
+++ b/src/Mandarin.Interfaces/Stockists/Stockist.cs
@@ -10,7 +10,7 @@ namespace Mandarin.Stockists
     public class Stockist
     {
         /// <summary>
-        /// Gets or sets the Database Stockist ID.
+        /// Gets or sets the Stockist's unique ID.
         /// </summary>
         [Key]
         public int StockistId { get; set; }

--- a/tests/Mandarin.Client.Services.Tests/Extensions/StockistFluentAssertionExtensions.cs
+++ b/tests/Mandarin.Client.Services.Tests/Extensions/StockistFluentAssertionExtensions.cs
@@ -5,11 +5,6 @@ namespace Mandarin.Client.Services.Tests.Extensions
 {
     internal static class StockistFluentAssertionExtensions
     {
-        public static void MatchStockist(this ObjectAssertions assertions, Stockist expected)
-        {
-            assertions.BeEquivalentTo(expected, o => o.IgnoringCyclicReferences());
-        }
-
         public static void MatchStockistIgnoringIds(this ObjectAssertions assertions, Stockist expected)
         {
             assertions.BeEquivalentTo(expected,

--- a/tests/Mandarin.Client.Services.Tests/Stockists/MandarinGrpcStockistServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Stockists/MandarinGrpcStockistServiceTests.cs
@@ -29,7 +29,7 @@ namespace Mandarin.Client.Services.Tests.Stockists
             async Task VerifyStockist(Stockist expected)
             {
                 var actual = await this.Subject.GetStockistByCodeAsync(expected.StockistCode);
-                actual.Should().MatchStockist(expected);
+                actual.Should().BeEquivalentTo(expected);
             }
         }
 

--- a/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistViewModelTests.cs
@@ -1,0 +1,18 @@
+﻿using FluentAssertions;
+using Mandarin.Client.ViewModels.Artists;
+using Mandarin.Tests.Data;
+using Xunit;
+
+namespace Mandarin.Client.ViewModels.Tests.Artists
+{
+    public class ArtistViewModelTests
+    {
+        [Fact]
+        public void ShouldRoundTripAnExistingStockist()
+        {
+            var subject = new ArtistViewModel(WellKnownTestData.Stockists.OthilieMapples);
+            subject.ToStockist().Should().BeEquivalentTo(WellKnownTestData.Stockists.OthilieMapples,
+                                                         o => o.Excluding(x => x.Commission.InsertedAt));
+        }
+    }
+}

--- a/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistsEditViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistsEditViewModelTests.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Mandarin.Client.ViewModels.Artists;
+using Mandarin.Client.ViewModels.Tests.Helpers;
+using Mandarin.Common;
+using Mandarin.Stockists;
+using Mandarin.Tests.Data;
+using Moq;
+using Xunit;
+
+namespace Mandarin.Client.ViewModels.Tests.Artists
+{
+    public class ArtistsEditViewModelTests
+    {
+        private readonly Fixture fixture = new();
+        private readonly Mock<IStockistService> stockistService = new();
+        private readonly MockNavigationManager navigationManager = new();
+        private readonly Mock<IValidator<IArtistViewModel>> artistValidator = new();
+
+        private readonly IArtistsEditViewModel subject;
+
+        protected ArtistsEditViewModelTests()
+        {
+            this.subject = new ArtistsEditViewModel(this.stockistService.Object, this.navigationManager, this.artistValidator.Object);
+        }
+
+        private void GivenServiceReturnsStockist(Stockist stockist)
+        {
+            this.stockistService.Setup(x => x.GetStockistByCodeAsync(stockist.StockistCode)).ReturnsAsync(stockist);
+        }
+
+        private void GivenValidationResult(ValidationResult validationResult)
+        {
+            this.artistValidator
+                .Setup(x => x.ValidateAsync(It.IsAny<IArtistViewModel>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validationResult);
+        }
+
+        public class IsLoadingTests : ArtistsEditViewModelTests
+        {
+            [Fact]
+            public void ShouldBeFalseOnConstruction()
+            {
+                this.subject.IsLoading.Should().BeFalse();
+            }
+
+            [Fact]
+            public void ShouldBeTrueWhilstExecuting()
+            {
+                var tcs = new TaskCompletionSource<Stockist>();
+                this.stockistService.Setup(x => x.GetStockistByCodeAsync(It.IsAny<string>())).Returns(tcs.Task);
+
+                var unused = this.subject.LoadData.Execute().ToTask();
+
+                this.subject.IsLoading.Should().BeTrue();
+                tcs.SetCanceled();
+            }
+
+            [Fact]
+            public async Task ShouldBeFalseAfterLoadingFinishes()
+            {
+                this.GivenServiceReturnsStockist(WellKnownTestData.Stockists.KelbyTynan);
+
+                await this.subject.LoadData.Execute(WellKnownTestData.Stockists.KelbyTynan.StockistCode);
+
+                this.subject.IsLoading.Should().BeFalse();
+            }
+        }
+
+        public class StockistTests : ArtistsEditViewModelTests
+        {
+            [Fact]
+            public async Task ShouldPopulateStockistAfterLoadingData()
+            {
+                this.GivenServiceReturnsStockist(WellKnownTestData.Stockists.OthilieMapples);
+
+                await this.subject.LoadData.Execute(WellKnownTestData.Stockists.OthilieMapples.StockistCode);
+
+                this.subject.Stockist.StockistId.Should().Be(4);
+                this.subject.Stockist.StockistCode.Should().Be("OM19");
+                this.subject.Stockist.StatusCode.Should().Be(StatusMode.ActiveHidden);
+                this.subject.Stockist.FirstName.Should().Be("Othilie");
+                this.subject.Stockist.LastName.Should().Be("Mapples");
+                this.subject.Stockist.DisplayName.Should().Be("Othilie Mapples");
+                this.subject.Stockist.TwitterHandle.Should().Be("ropfer3");
+                this.subject.Stockist.InstagramHandle.Should().Be("ropfer3");
+                this.subject.Stockist.FacebookHandle.Should().BeNull();
+                this.subject.Stockist.WebsiteUrl.Should().Be("http://mtv.com/non/mauris/morbi.jsp");
+                this.subject.Stockist.TumblrHandle.Should().BeNull();
+                this.subject.Stockist.EmailAddress.Should().Be("jgunny3@unicef.org");
+                this.subject.Stockist.CommissionId.Should().Be(4);
+                this.subject.Stockist.StartDate.Should().Be(new DateTime(2019, 01, 16));
+                this.subject.Stockist.EndDate.Should().Be(new DateTime(2019, 04, 16));
+                this.subject.Stockist.Rate.Should().Be(40);
+            }
+        }
+
+        public class StatusesTests : ArtistsEditViewModelTests
+        {
+            [Fact]
+            public void ShouldHaveCorrectAvailableOptions()
+            {
+                var statuses = this.subject.Statuses;
+                statuses.Should().BeEquivalentTo(StatusMode.Inactive, StatusMode.ActiveHidden, StatusMode.Active);
+            }
+        }
+
+        public class SaveTests : ArtistsEditViewModelTests, IAsyncLifetime
+        {
+            private readonly ValidationResult failure;
+            private readonly ValidationResult success;
+
+            public SaveTests()
+            {
+                this.failure = new ValidationResult(this.fixture.CreateMany<ValidationFailure>());
+                this.success = new ValidationResult();
+            }
+
+            /// <inheritdoc />
+            public async Task InitializeAsync()
+            {
+                this.GivenServiceReturnsStockist(WellKnownTestData.Stockists.ArlueneWoodes);
+                await this.subject.LoadData.Execute(WellKnownTestData.Stockists.ArlueneWoodes.StockistCode);
+            }
+
+            /// <inheritdoc />
+            public Task DisposeAsync()
+            {
+                return Task.CompletedTask;
+            }
+
+            [Fact]
+            public async Task ShouldUpdateValidationResultOnSaving()
+            {
+                this.GivenValidationResult(this.failure);
+
+                await this.subject.Save.Execute();
+                this.subject.ValidationResult.Should().Be(this.failure);
+            }
+
+            [Fact]
+            public async Task ShouldNotCallServiceIfValidationFails()
+            {
+                this.GivenValidationResult(this.failure);
+                await this.subject.Save.Execute();
+                this.stockistService.Verify(x => x.SaveStockistAsync(It.IsAny<Stockist>()), Times.Never());
+            }
+
+            [Fact]
+            public async Task ShouldCallServiceOnSuccessfulValidation()
+            {
+                this.GivenValidationResult(this.success);
+                await this.subject.Save.Execute();
+                this.stockistService.Verify(x => x.SaveStockistAsync(It.IsAny<Stockist>()), Times.Once());
+            }
+
+            [Fact]
+            public async Task ShouldNavigateToEditEditArtistOnSuccess()
+            {
+                this.GivenValidationResult(this.success);
+
+                this.subject.Stockist.StockistCode = "TLM";
+                await this.subject.Save.Execute();
+
+                this.navigationManager.Uri.Should().EndWith("/artists");
+            }
+        }
+
+        public class CancelTests : ArtistsEditViewModelTests
+        {
+            [Fact]
+            public async Task ShouldRedirectToIndexPageOnCancelling()
+            {
+                await this.subject.Cancel.Execute();
+                this.navigationManager.Uri.Should().EndWith("/artists");
+            }
+        }
+    }
+}

--- a/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistsNewViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistsNewViewModelTests.cs
@@ -10,7 +10,6 @@ using Mandarin.Client.ViewModels.Artists;
 using Mandarin.Client.ViewModels.Tests.Helpers;
 using Mandarin.Common;
 using Mandarin.Stockists;
-using Microsoft.AspNetCore.Components;
 using Moq;
 using Xunit;
 

--- a/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistsNewViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Artists/ArtistsNewViewModelTests.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Mandarin.Client.ViewModels.Artists;
+using Mandarin.Client.ViewModels.Tests.Helpers;
+using Mandarin.Common;
+using Mandarin.Stockists;
+using Microsoft.AspNetCore.Components;
+using Moq;
+using Xunit;
+
+namespace Mandarin.Client.ViewModels.Tests.Artists
+{
+    public class ArtistsNewViewModelTests
+    {
+        private readonly Fixture fixture = new();
+        private readonly Mock<IStockistService> stockistService = new();
+        private readonly MockNavigationManager navigationManager = new();
+        private readonly Mock<IValidator<IArtistViewModel>> artistValidator = new();
+
+        private IArtistsNewViewModel Subject =>
+            new ArtistsNewViewModel(this.stockistService.Object, this.navigationManager, this.artistValidator.Object);
+
+        private void GivenValidationResult(ValidationResult validationResult)
+        {
+            this.artistValidator
+                .Setup(x => x.ValidateAsync(It.IsAny<IArtistViewModel>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(validationResult);
+        }
+
+        public class StockistTests : ArtistsNewViewModelTests
+        {
+            [Fact]
+            public void ShouldHaveDefaultStockistOnConstruction()
+            {
+                var stockist = this.Subject.Stockist;
+                stockist.StatusCode.Should().Be(StatusMode.Active);
+                stockist.Rate.Should().Be(100);
+                stockist.StartDate.Should().Be(DateTime.Today);
+                stockist.EndDate.Should().Be(DateTime.Today.AddDays(90));
+            }
+        }
+
+        public class StatusesTests : ArtistsNewViewModelTests
+        {
+            [Fact]
+            public void ShouldHaveCorrectAvailableOptions()
+            {
+                var statuses = this.Subject.Statuses;
+                statuses.Should().BeEquivalentTo(StatusMode.Inactive, StatusMode.ActiveHidden, StatusMode.Active);
+            }
+        }
+
+        public class SaveTests : ArtistsNewViewModelTests
+        {
+            private readonly ValidationResult failure;
+            private readonly ValidationResult success;
+
+            public SaveTests()
+            {
+                this.failure = new ValidationResult(this.fixture.CreateMany<ValidationFailure>());
+                this.success = new ValidationResult();
+            }
+
+            [Fact]
+            public async Task ShouldUpdateValidationResultOnSaving()
+            {
+                this.GivenValidationResult(this.failure);
+                var subject = this.Subject;
+
+                await subject.Save.Execute();
+                subject.ValidationResult.Should().Be(this.failure);
+            }
+
+            [Fact]
+            public async Task ShouldNotCallServiceIfValidationFails()
+            {
+                this.GivenValidationResult(this.failure);
+                await this.Subject.Save.Execute();
+                this.stockistService.Verify(x => x.SaveStockistAsync(It.IsAny<Stockist>()), Times.Never());
+            }
+
+            [Fact]
+            public async Task ShouldCallServiceOnSuccessfulValidation()
+            {
+                this.GivenValidationResult(this.success);
+                await this.Subject.Save.Execute();
+                this.stockistService.Verify(x => x.SaveStockistAsync(It.IsAny<Stockist>()), Times.Once());
+            }
+
+            [Fact]
+            public async Task ShouldNavigateToEditNewArtistOnSuccess()
+            {
+                this.GivenValidationResult(this.success);
+                var subject = this.Subject;
+
+                subject.Stockist.StockistCode = "TLM";
+                await subject.Save.Execute();
+
+                this.navigationManager.Uri.Should().EndWith("/artists/edit/TLM");
+            }
+        }
+
+        public class CancelTests : ArtistsNewViewModelTests
+        {
+            [Fact]
+            public async Task ShouldRedirectToIndexPageOnCancelling()
+            {
+                await this.Subject.Cancel.Execute();
+                this.navigationManager.Uri.Should().EndWith("/artists");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Frame prices bedded in the usage of ReactiveUI for the backing logic behind each View. This PR copies that into the Artist pages and also cleans up the verboseness of Blazorise's validation framework, with a combination of FluentValidation to push validation onto the ViewModels and reusable components to make the top component clearer.