### PR TITLE
BASHI-132: Fix error where ProductId could contain a null value.

### DIFF
--- a/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Artists/ArtistViewModel.cs
@@ -155,13 +155,13 @@ namespace Mandarin.Client.ViewModels.Artists
         /// <inheritdoc/>
         public Stockist ToStockist()
         {
-            var stockistId = this.StockistId.HasValue ? new StockistId(this.StockistId.Value) : null;
-            var commissionId = this.CommissionId.HasValue ? new CommissionId(this.CommissionId.Value) : null;
+            var stockistId = Stockists.StockistId.Of(this.StockistId);
+            var commissionId = Mandarin.Commissions.CommissionId.Of(this.CommissionId);
 
             return new Stockist
             {
                 StockistId = stockistId,
-                StockistCode = new StockistCode(this.StockistCode),
+                StockistCode = Stockists.StockistCode.Of(this.StockistCode),
                 StatusCode = this.StatusCode,
                 Details = new StockistDetail
                 {

--- a/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePriceViewModel.cs
+++ b/src/Mandarin.Client.ViewModels/Inventory/FramePrices/FramePriceViewModel.cs
@@ -90,7 +90,7 @@ namespace Mandarin.Client.ViewModels.Inventory.FramePrices
         {
             return new FramePrice
             {
-                ProductCode = new ProductCode(this.productCode),
+                ProductCode = Mandarin.Inventory.ProductCode.Of(this.productCode),
                 Amount = this.FramePrice ?? throw new InvalidOperationException("No frame price has been set."),
                 CreatedAt = this.CreatedAt ?? DateTime.Now,
             };

--- a/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
+++ b/src/Mandarin.Client/Pages/Artists/ArtistsEdit.razor
@@ -69,7 +69,7 @@
   protected override async Task OnParametersSetAsync()
   {
     await base.OnParametersSetAsync();
-    await ViewModel!.LoadData.Execute(new StockistCode(StockistCode));
+    await ViewModel!.LoadData.Execute(Stockists.StockistCode.Of(StockistCode));
 
     this.EditContext = new EditContext(Stockist);
     this.EditContext.SubscribeToViewModel(ViewModel, () => validations.ValidateAll());

--- a/src/Mandarin.Client/Pages/Inventory/FramePrices/FramePricesEdit.razor
+++ b/src/Mandarin.Client/Pages/Inventory/FramePrices/FramePricesEdit.razor
@@ -54,7 +54,7 @@
   /// <inheritdoc />
   protected override async Task OnParametersSetAsync()
   {
-    await ViewModel!.LoadData.Execute(new ProductCode(ProductCode));
+    await ViewModel!.LoadData.Execute(Mandarin.Inventory.ProductCode.Of(ProductCode));
 
     this.EditContext = new EditContext(FramePrice);
     this.EditContext.SubscribeToViewModel(ViewModel, () => validations.ValidateAll());

--- a/src/Mandarin.Interfaces/Commissions/CommissionId.cs
+++ b/src/Mandarin.Interfaces/Commissions/CommissionId.cs
@@ -11,9 +11,16 @@ namespace Mandarin.Commissions
         /// Initializes a new instance of the <see cref="CommissionId"/> class.
         /// </summary>
         /// <param name="value">The unique Commission ID.</param>
-        public CommissionId(int value)
+        private CommissionId(int value)
             : base(value)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommissionId"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Commission Id.</param>
+        /// <returns>A newly created <see cref="CommissionId"/> or null/empty.</returns>
+        public static CommissionId Of(int? value) => value.HasValue ? new CommissionId(value.Value) : null;
     }
 }

--- a/src/Mandarin.Interfaces/Converters/MandarinTinyTypeMapperProfile.cs
+++ b/src/Mandarin.Interfaces/Converters/MandarinTinyTypeMapperProfile.cs
@@ -15,19 +15,19 @@ namespace Mandarin.Converters
         /// </summary>
         public MandarinTinyTypeMapperProfile()
         {
-            this.CreateMap<int, CommissionId>().ConstructUsing(x => new CommissionId(x))
+            this.CreateMap<int, CommissionId>().ConstructUsing(x => CommissionId.Of(x))
                 .ReverseMap().ConstructUsing(x => x.Value);
 
-            this.CreateMap<string, ProductId>().ConstructUsing(x => new ProductId(x))
+            this.CreateMap<string, ProductId>().ConstructUsing(x => ProductId.Of(x))
                 .ReverseMap().ConstructUsing(x => x.Value);
-            this.CreateMap<string, ProductCode>().ConstructUsing(x => new ProductCode(x))
+            this.CreateMap<string, ProductCode>().ConstructUsing(x => ProductCode.Of(x))
                 .ReverseMap().ConstructUsing(x => x.Value);
-            this.CreateMap<string, ProductName>().ConstructUsing(x => new ProductName(x))
+            this.CreateMap<string, ProductName>().ConstructUsing(x => ProductName.Of(x))
                 .ReverseMap().ConstructUsing(x => x.Value);
 
-            this.CreateMap<int, StockistId>().ConstructUsing(x => new StockistId(x))
+            this.CreateMap<int, StockistId>().ConstructUsing(x => StockistId.Of(x))
                 .ReverseMap().ConstructUsing(x => x.Value);
-            this.CreateMap<string, StockistCode>().ConstructUsing(x => new StockistCode(x))
+            this.CreateMap<string, StockistCode>().ConstructUsing(x => StockistCode.Of(x))
                 .ReverseMap().ConstructUsing(x => x.Value);
         }
     }

--- a/src/Mandarin.Interfaces/Inventory/ProductCode.cs
+++ b/src/Mandarin.Interfaces/Inventory/ProductCode.cs
@@ -11,9 +11,16 @@ namespace Mandarin.Inventory
         /// Initializes a new instance of the <see cref="ProductCode"/> class.
         /// </summary>
         /// <param name="value">The unique Product Code.</param>
-        public ProductCode(string value)
+        private ProductCode(string value)
             : base(value)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductCode"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Product Code.</param>
+        /// <returns>A newly created <see cref="ProductCode"/> or null/empty.</returns>
+        public static ProductCode Of(string value) => string.IsNullOrEmpty(value) ? null : new ProductCode(value);
     }
 }

--- a/src/Mandarin.Interfaces/Inventory/ProductId.cs
+++ b/src/Mandarin.Interfaces/Inventory/ProductId.cs
@@ -11,9 +11,16 @@ namespace Mandarin.Inventory
         /// Initializes a new instance of the <see cref="ProductId"/> class.
         /// </summary>
         /// <param name="value">The unique Product Id.</param>
-        public ProductId(string value)
+        private ProductId(string value)
             : base(value)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductId"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Product Id.</param>
+        /// <returns>A newly created <see cref="ProductId"/> or null/empty.</returns>
+        public static ProductId Of(string value) => string.IsNullOrEmpty(value) ? null : new ProductId(value);
     }
 }

--- a/src/Mandarin.Interfaces/Inventory/ProductName.cs
+++ b/src/Mandarin.Interfaces/Inventory/ProductName.cs
@@ -12,9 +12,16 @@ namespace Mandarin.Inventory
         /// Initializes a new instance of the <see cref="ProductName"/> class.
         /// </summary>
         /// <param name="value">The unique Product Name.</param>
-        public ProductName(string value)
+        private ProductName(string value)
             : base(value, StringComparer.OrdinalIgnoreCase)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProductName"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Product Name.</param>
+        /// <returns>A newly created <see cref="ProductName"/> or null/empty.</returns>
+        public static ProductName Of(string value) => string.IsNullOrEmpty(value) ? null : new ProductName(value);
     }
 }

--- a/src/Mandarin.Interfaces/Stockists/StockistCode.cs
+++ b/src/Mandarin.Interfaces/Stockists/StockistCode.cs
@@ -11,9 +11,16 @@ namespace Mandarin.Stockists
         /// Initializes a new instance of the <see cref="StockistCode"/> class.
         /// </summary>
         /// <param name="value">The unique Stockist Code.</param>
-        public StockistCode(string value)
+        private StockistCode(string value)
             : base(value)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StockistCode"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Stockist Code.</param>
+        /// <returns>A newly created <see cref="StockistCode"/> or null/empty.</returns>
+        public static StockistCode Of(string value) => string.IsNullOrEmpty(value) ? null : new StockistCode(value);
     }
 }

--- a/src/Mandarin.Interfaces/Stockists/StockistId.cs
+++ b/src/Mandarin.Interfaces/Stockists/StockistId.cs
@@ -11,9 +11,16 @@ namespace Mandarin.Stockists
         /// Initializes a new instance of the <see cref="StockistId"/> class.
         /// </summary>
         /// <param name="value">The unique Stockist ID.</param>
-        public StockistId(int value)
+        private StockistId(int value)
             : base(value)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StockistId"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Stockist Id.</param>
+        /// <returns>A newly created <see cref="StockistId"/> or null/empty.</returns>
+        public static StockistId Of(int? value) => value.HasValue ? new StockistId(value.Value) : null;
     }
 }

--- a/src/Mandarin.Interfaces/Transactions/TransactionId.cs
+++ b/src/Mandarin.Interfaces/Transactions/TransactionId.cs
@@ -11,9 +11,16 @@ namespace Mandarin.Transactions
         /// Initializes a new instance of the <see cref="TransactionId"/> class.
         /// </summary>
         /// <param name="value">The unique Transaction Id.</param>
-        public TransactionId(string value)
+        private TransactionId(string value)
             : base(value)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionId"/> class, or null if the given <paramref name="value"/> is null/empty.
+        /// </summary>
+        /// <param name="value">The unique Transaction Id.</param>
+        /// <returns>A newly created <see cref="TransactionId"/> or null/empty.</returns>
+        public static TransactionId Of(string value) => string.IsNullOrEmpty(value) ? null : new TransactionId(value);
     }
 }

--- a/src/Mandarin.Services/Commission/CommissionService.cs
+++ b/src/Mandarin.Services/Commission/CommissionService.cs
@@ -43,7 +43,7 @@ namespace Mandarin.Services.Commission
 
             var aggregateTransactions = transactions
                                         .SelectMany(transaction => transaction.Subtransactions.NullToEmpty())
-                                        .GroupBy(subtransaction => (subtransaction.Product?.ProductCode ?? new ProductCode("TLM-Unknown"), subtransaction.TransactionUnitPrice))
+                                        .GroupBy(subtransaction => (subtransaction.Product?.ProductCode ?? ProductCode.Of("TLM-Unknown"), subtransaction.TransactionUnitPrice))
                                         .Select(ToAggregateSubtransaction)
                                         .ToList();
 

--- a/src/Mandarin.Services/Inventory/SquareProductService.cs
+++ b/src/Mandarin.Services/Inventory/SquareProductService.cs
@@ -106,9 +106,9 @@ namespace Mandarin.Services.Inventory
 
                 yield return new Product
                 {
-                    ProductId = new ProductId(variation.Id),
-                    ProductCode = new ProductCode(variation.ItemVariationData.Sku),
-                    ProductName = new ProductName($"{productName} ({variation.ItemVariationData.Name})"),
+                    ProductId = ProductId.Of(variation.Id),
+                    ProductCode = ProductCode.Of(variation.ItemVariationData.Sku),
+                    ProductName = ProductName.Of($"{productName} ({variation.ItemVariationData.Name})"),
                     Description = description,
                     UnitPrice = unitPrice,
                     LastUpdated = DateTime.Parse(variation.UpdatedAt),

--- a/src/Mandarin.Services/Transactions/TransactionMapper.cs
+++ b/src/Mandarin.Services/Transactions/TransactionMapper.cs
@@ -41,7 +41,7 @@ namespace Mandarin.Services.Transactions
             return this.CreateSubtransactions(order)
                        .Select(subtransactions => new Transaction()
                        {
-                           SquareId = new TransactionId(order.Id),
+                           SquareId = TransactionId.Of(order.Id),
                            TotalAmount = decimal.Divide(order.TotalMoney?.Amount ?? 0, 100),
                            Timestamp = DateTime.Parse(order.CreatedAt),
                            InsertedBy = order.Source?.Name,
@@ -61,7 +61,7 @@ namespace Mandarin.Services.Transactions
 
         private IObservable<Subtransaction> CreateSubtransaction(OrderLineItem orderLineItem, DateTime orderDate)
         {
-            return this.GetProductAsync(new ProductId(orderLineItem.CatalogObjectId), new ProductName(orderLineItem.Name), orderDate)
+            return this.GetProductAsync(ProductId.Of(orderLineItem.CatalogObjectId), ProductName.Of(orderLineItem.Name), orderDate)
                        .ToObservable()
                        .SelectMany(product =>
                        {
@@ -89,9 +89,9 @@ namespace Mandarin.Services.Transactions
                     {
                         Product = new Product
                         {
-                            ProductId = new ProductId("TLM-" + framePrice.ProductCode),
-                            ProductCode = new ProductCode("TLM-" + framePrice.ProductCode),
-                            ProductName = new ProductName($"Frame for {framePrice.ProductCode}"),
+                            ProductId = ProductId.Of("TLM-" + framePrice.ProductCode),
+                            ProductCode = ProductCode.Of("TLM-" + framePrice.ProductCode),
+                            ProductName = ProductName.Of($"Frame for {framePrice.ProductCode}"),
                             Description = null,
                             UnitPrice = framePrice.Amount,
                         },
@@ -121,9 +121,9 @@ namespace Mandarin.Services.Transactions
             {
                 product = new Product
                 {
-                    ProductId = new ProductId("BUN-DCM"),
-                    ProductCode = new ProductCode("BUN-DCM"),
-                    ProductName = new ProductName("Box of Macarons Discount"),
+                    ProductId = ProductId.Of("BUN-DCM"),
+                    ProductCode = ProductCode.Of("BUN-DCM"),
+                    ProductName = ProductName.Of("Box of Macarons Discount"),
                     Description = "Buy 6 macarons for \"£12.00\"",
                     UnitPrice = -0.01m,
                 };
@@ -132,9 +132,9 @@ namespace Mandarin.Services.Transactions
             {
                 product = new Product
                 {
-                    ProductId = new ProductId("BUN-DCP"),
-                    ProductCode = new ProductCode("BUN-DCP"),
-                    ProductName = new ProductName("Box of Pocky Discount"),
+                    ProductId = ProductId.Of("BUN-DCP"),
+                    ProductCode = ProductCode.Of("BUN-DCP"),
+                    ProductName = ProductName.Of("Box of Pocky Discount"),
                     Description = "Discount on buying multiple packs of Pocky.",
                     UnitPrice = -0.01m,
                 };
@@ -143,9 +143,9 @@ namespace Mandarin.Services.Transactions
             {
                 product = new Product
                 {
-                    ProductId = new ProductId("TLM-D"),
-                    ProductCode = new ProductCode("TLM-D"),
-                    ProductName = new ProductName("Other discounts"),
+                    ProductId = ProductId.Of("TLM-D"),
+                    ProductCode = ProductCode.Of("TLM-D"),
+                    ProductName = ProductName.Of("Other discounts"),
                     Description = "Discounts that aren't tracked.",
                     UnitPrice = -0.01m,
                 };
@@ -166,7 +166,7 @@ namespace Mandarin.Services.Transactions
             return orderReturn.ReturnLineItems.ToObservable()
                               .SelectMany(async item =>
                               {
-                                  var product = await this.GetProductAsync(new ProductId(item.CatalogObjectId), new ProductName(item.Name), orderDate);
+                                  var product = await this.GetProductAsync(ProductId.Of(item.CatalogObjectId), ProductName.Of(item.Name), orderDate);
                                   var quantity = -1 * int.Parse(item.Quantity);
                                   var subtotal = quantity * decimal.Divide(item.BasePriceMoney?.Amount ?? 0, 100);
 
@@ -186,9 +186,9 @@ namespace Mandarin.Services.Transactions
             {
                 product = new Product
                 {
-                    ProductId = new ProductId("TLM-DELIVERY"),
-                    ProductCode = new ProductCode("TLM-DELIVERY"),
-                    ProductName = new ProductName("Shipping Fees"),
+                    ProductId = ProductId.Of("TLM-DELIVERY"),
+                    ProductCode = ProductCode.Of("TLM-DELIVERY"),
+                    ProductName = ProductName.Of("Shipping Fees"),
                     Description = "Delivery costs charged to customers.",
                     UnitPrice = 0.01m,
                 };
@@ -197,9 +197,9 @@ namespace Mandarin.Services.Transactions
             {
                 product = new Product
                 {
-                    ProductId = new ProductId("TLM-FEES"),
-                    ProductCode = new ProductCode("TLM-" + serviceCharge.Name),
-                    ProductName = new ProductName(serviceCharge.Name),
+                    ProductId = ProductId.Of("TLM-FEES"),
+                    ProductCode = ProductCode.Of("TLM-" + serviceCharge.Name),
+                    ProductName = ProductName.Of(serviceCharge.Name),
                     Description = "Unknown Fee.",
                     UnitPrice = 0.01m,
                 };
@@ -232,8 +232,8 @@ namespace Mandarin.Services.Transactions
                 return new Product
                 {
                     ProductId = null,
-                    ProductCode = new ProductCode("TLM-Unknown"),
-                    ProductName = new ProductName("Unknown Product"),
+                    ProductCode = ProductCode.Of("TLM-Unknown"),
+                    ProductName = ProductName.Of("Unknown Product"),
                     Description = "Unknown Product",
                     UnitPrice = null,
                 };
@@ -245,7 +245,7 @@ namespace Mandarin.Services.Transactions
                 {
                     if (orderDate > mapping.TransactionsAfterDate && mapping.Mappings.ContainsKey(originalProduct.ProductCode.Value))
                     {
-                        var mappedProductCode = new ProductCode(mapping.Mappings[originalProduct.ProductCode.Value]);
+                        var mappedProductCode = ProductCode.Of(mapping.Mappings[originalProduct.ProductCode.Value]);
                         return this.productRepository.GetProductAsync(mappedProductCode);
                     }
                 }

--- a/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcFramePricesServiceTests.cs
@@ -31,7 +31,7 @@ namespace Mandarin.Client.Services.Tests.Inventory
             var today = new DateTime(2021, 06, 30);
             var newFramePrice = new FramePrice
             {
-                ProductCode = new ProductCode("KT20-001F"),
+                ProductCode = ProductCode.Of("KT20-001F"),
                 Amount = 25.00M,
                 CreatedAt = today,
             };
@@ -46,13 +46,13 @@ namespace Mandarin.Client.Services.Tests.Inventory
         {
             var framePrice = new FramePrice
             {
-                ProductCode = new ProductCode("OM19-001"),
+                ProductCode = ProductCode.Of("OM19-001"),
                 Amount = 15.00M,
                 CreatedAt = new DateTime(2021, 06, 30),
             };
             await this.Subject.SaveFramePriceAsync(framePrice);
 
-            var newFramePrice = await this.Subject.GetFramePriceAsync(new ProductCode("OM19-001"), DateTime.Now);
+            var newFramePrice = await this.Subject.GetFramePriceAsync(ProductCode.Of("OM19-001"), DateTime.Now);
             newFramePrice.Should().BeEquivalentTo(framePrice);
         }
 
@@ -61,35 +61,35 @@ namespace Mandarin.Client.Services.Tests.Inventory
         {
             var expected = new FramePrice
             {
-                ProductCode = new ProductCode("KT20-001F"),
+                ProductCode = ProductCode.Of("KT20-001F"),
                 Amount = 50.00M,
                 CreatedAt = new DateTime(2019, 06, 01),
                 ActiveUntil = null,
             };
 
-            (await this.Subject.GetFramePriceAsync(new ProductCode("KT20-001F"), DateTime.Now)).Should().Be(expected);
+            (await this.Subject.GetFramePriceAsync(ProductCode.Of("KT20-001F"), DateTime.Now)).Should().Be(expected);
 
             var today = new DateTime(2021, 06, 30);
             var newFramePrice = new FramePrice
             {
-                ProductCode = new ProductCode("KT20-001F"),
+                ProductCode = ProductCode.Of("KT20-001F"),
                 Amount = 25.00M,
                 CreatedAt = today,
             };
             await this.Subject.SaveFramePriceAsync(newFramePrice);
 
-            (await this.Subject.GetFramePriceAsync(new ProductCode("KT20-001F"), new DateTime(2021, 05, 15))).Should().Be(expected with { ActiveUntil = today });
-            (await this.Subject.GetFramePriceAsync(new ProductCode("KT20-001F"), today)).Should().Be(newFramePrice);
+            (await this.Subject.GetFramePriceAsync(ProductCode.Of("KT20-001F"), new DateTime(2021, 05, 15))).Should().Be(expected with { ActiveUntil = today });
+            (await this.Subject.GetFramePriceAsync(ProductCode.Of("KT20-001F"), today)).Should().Be(newFramePrice);
         }
 
         [Fact]
         public async Task ShouldBeAbleToDeleteAFramePrice()
         {
-            await this.Subject.DeleteFramePriceAsync(new ProductCode("KT20-001F"));
+            await this.Subject.DeleteFramePriceAsync(ProductCode.Of("KT20-001F"));
 
-            var deletedFramePrice = await this.Subject.GetFramePriceAsync(new ProductCode("KT20-001F"), DateTime.Now);
+            var deletedFramePrice = await this.Subject.GetFramePriceAsync(ProductCode.Of("KT20-001F"), DateTime.Now);
             deletedFramePrice.Should().BeNull();
-            var existingFramePrice = await this.Subject.GetFramePriceAsync(new ProductCode("KT20-002F"), DateTime.Now);
+            var existingFramePrice = await this.Subject.GetFramePriceAsync(ProductCode.Of("KT20-002F"), DateTime.Now);
             existingFramePrice.Should().NotBeNull();
         }
     }

--- a/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcProductServiceTests.cs
+++ b/tests/Mandarin.Client.Services.Tests/Inventory/MandarinGrpcProductServiceTests.cs
@@ -28,28 +28,28 @@ namespace Mandarin.Client.Services.Tests.Inventory
         [Fact]
         public async Task ShouldBeAbleToRetrieveProductBySquareId()
         {
-            var product = await this.Subject.GetProductAsync(new ProductId("BTWEJWZCPE4XAKZRBJW53DYE"));
+            var product = await this.Subject.GetProductAsync(ProductId.Of("BTWEJWZCPE4XAKZRBJW53DYE"));
             product.Should().BeEquivalentTo(WellKnownTestData.Products.ClementineFramed);
         }
 
         [Fact]
         public async Task ShouldBeAbleToRetrieveProductByCode()
         {
-            var product = await this.Subject.GetProductAsync(new ProductCode("KT20-001F"));
+            var product = await this.Subject.GetProductAsync(ProductCode.Of("KT20-001F"));
             product.Should().BeEquivalentTo(WellKnownTestData.Products.ClementineFramed);
         }
 
         [Fact]
         public async Task ShouldBeAbleToRetrieveGiftCard()
         {
-            var product = await this.Subject.GetProductAsync(new ProductCode("TLM-GC"));
+            var product = await this.Subject.GetProductAsync(ProductCode.Of("TLM-GC"));
             product.Should().BeEquivalentTo(WellKnownTestData.Products.GiftCard, o => o.Excluding(x => x.LastUpdated));
         }
 
         [Fact]
         public async Task ShouldBeAbleToRetrieveProductName()
         {
-            var product = await this.Subject.GetProductAsync(new ProductName("Clementine (Framed)"));
+            var product = await this.Subject.GetProductAsync(ProductName.Of("Clementine (Framed)"));
             product.Should().BeEquivalentTo(WellKnownTestData.Products.ClementineFramed);
         }
     }

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePriceViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePriceViewModelTests.cs
@@ -11,7 +11,7 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
     {
         private static readonly FramePrice FramePrice = new()
         {
-            ProductCode = new ProductCode("TLM-001"),
+            ProductCode = ProductCode.Of("TLM-001"),
             Amount = 15.00M,
             CreatedAt = new DateTime(2021, 07, 01),
         };

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesEditViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesEditViewModelTests.cs
@@ -65,7 +65,7 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
                 var tcs = new TaskCompletionSource<Product>();
                 this.productRepository.Setup(x => x.GetProductAsync(It.IsAny<ProductCode>())).Returns(tcs.Task);
 
-                var unused = this.subject.LoadData.Execute(new ProductCode("TLM-001")).ToTask();
+                var unused = this.subject.LoadData.Execute(ProductCode.Of("TLM-001")).ToTask();
 
                 this.subject.IsLoading.Should().BeTrue();
                 tcs.SetCanceled();

--- a/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesIndexViewModelTests.cs
+++ b/tests/Mandarin.Client.ViewModels.Tests/Inventory/FramePrices/FramePricesIndexViewModelTests.cs
@@ -16,7 +16,7 @@ namespace Mandarin.Client.ViewModels.Tests.Inventory.FramePrices
     {
         private static readonly FramePrice FramePrice = new()
         {
-            ProductCode = new ProductCode("TLM-001"),
+            ProductCode = ProductCode.Of("TLM-001"),
             Amount = 15.00M,
         };
 

--- a/tests/Mandarin.Services.Tests/Inventory/SquareProductServiceTests.cs
+++ b/tests/Mandarin.Services.Tests/Inventory/SquareProductServiceTests.cs
@@ -68,10 +68,10 @@ namespace Mandarin.Services.Tests.Inventory
                 var catalogObjects = await this.subject.GetAllProductsAsync();
 
                 catalogObjects.Should().HaveCount(2);
-                catalogObjects[0].ProductCode.Should().Be(new ProductCode("ID-1"));
-                catalogObjects[0].ProductName.Should().Be(new ProductName("Item1 (Regular)"));
-                catalogObjects[1].ProductCode.Should().Be(new ProductCode("ID-2"));
-                catalogObjects[1].ProductName.Should().Be(new ProductName("Item2 (Regular)"));
+                catalogObjects[0].ProductCode.Should().Be(ProductCode.Of("ID-1"));
+                catalogObjects[0].ProductName.Should().Be(ProductName.Of("Item1 (Regular)"));
+                catalogObjects[1].ProductCode.Should().Be(ProductCode.Of("ID-2"));
+                catalogObjects[1].ProductName.Should().Be(ProductName.Of("Item2 (Regular)"));
             }
         }
     }

--- a/tests/Mandarin.Services.Tests/Transactions/SquareTransactionServiceTests.cs
+++ b/tests/Mandarin.Services.Tests/Transactions/SquareTransactionServiceTests.cs
@@ -65,9 +65,9 @@ namespace Mandarin.Services.Tests.Transactions
         private void GivenTransactionMapperMapsTo()
         {
             this.transactionMapper.Setup(x => x.MapToTransaction(It.Is<Order>(o => o.Id == "Order1")))
-                .Returns(Observable.Return(TestData.Create<Transaction>() with { SquareId = new TransactionId("Order1") }));
+                .Returns(Observable.Return(TestData.Create<Transaction>() with { SquareId = TransactionId.Of("Order1") }));
             this.transactionMapper.Setup(x => x.MapToTransaction(It.Is<Order>(o => o.Id == "Order2")))
-                .Returns(Observable.Return(TestData.Create<Transaction>() with { SquareId = new TransactionId("Order2") }));
+                .Returns(Observable.Return(TestData.Create<Transaction>() with { SquareId = TransactionId.Of("Order2") }));
         }
 
         public class GetAllTransactionsTests : SquareTransactionServiceTests
@@ -94,8 +94,8 @@ namespace Mandarin.Services.Tests.Transactions
                 var transactions = await this.Subject.GetAllTransactions(DateTime.Now, DateTime.Now).ToList();
 
                 transactions.Should().HaveCount(2);
-                transactions[0].SquareId.Should().Be(new TransactionId("Order1"));
-                transactions[1].SquareId.Should().Be(new TransactionId("Order2"));
+                transactions[0].SquareId.Should().Be(TransactionId.Of("Order1"));
+                transactions[1].SquareId.Should().Be(TransactionId.Of("Order2"));
             }
         }
     }

--- a/tests/Mandarin.Tests.Data/Extensions/ProductTestExtensions.cs
+++ b/tests/Mandarin.Tests.Data/Extensions/ProductTestExtensions.cs
@@ -8,7 +8,7 @@ namespace Mandarin.Tests.Data.Extensions
         {
             return product with
             {
-                ProductCode = new ProductCode($"TLM-{product.ProductCode}"),
+                ProductCode = ProductCode.Of($"TLM-{product.ProductCode}"),
             };
         }
     }

--- a/tests/Mandarin.Tests.Data/WellKnownTestData.cs
+++ b/tests/Mandarin.Tests.Data/WellKnownTestData.cs
@@ -41,36 +41,36 @@ namespace Mandarin.Tests.Data
         {
             public static readonly Product Mandarin = new()
             {
-                ProductId = new ProductId("SquareId"),
-                ProductCode = new ProductCode("TLM-001"),
-                ProductName = new ProductName("Mandarin"),
+                ProductId = ProductId.Of("SquareId"),
+                ProductCode = ProductCode.Of("TLM-001"),
+                ProductName = ProductName.Of("Mandarin"),
                 Description = "It's a Mandarin!",
                 UnitPrice = 45.00M,
             };
 
             public static readonly Product TheTrickster = new()
             {
-                ProductId = new ProductId("CatalogId"),
-                ProductCode = new ProductCode("HC20W-003"),
-                ProductName = new ProductName("The Trickster"),
+                ProductId = ProductId.Of("CatalogId"),
+                ProductCode = ProductCode.Of("HC20W-003"),
+                ProductName = ProductName.Of("The Trickster"),
                 Description = "The Trickster.",
                 UnitPrice = 11.00m,
             };
 
             public static readonly Product ClementineFramed = new()
             {
-                ProductId = new ProductId("BTWEJWZCPE4XAKZRBJW53DYE"),
-                ProductCode = new ProductCode("KT20-001F"),
-                ProductName = new ProductName("Clementine (Framed) (Regular)"),
+                ProductId = ProductId.Of("BTWEJWZCPE4XAKZRBJW53DYE"),
+                ProductCode = ProductCode.Of("KT20-001F"),
+                ProductName = ProductName.Of("Clementine (Framed) (Regular)"),
                 Description = "vel augue vestibulum ante ipsum primis in",
                 UnitPrice = 95.00M,
             };
 
             public static readonly Product GiftCard = new()
             {
-                ProductId = new ProductId("TLM-GC"),
-                ProductCode = new ProductCode("TLM-GC"),
-                ProductName = new ProductName("eGift Card"),
+                ProductId = ProductId.Of("TLM-GC"),
+                ProductCode = ProductCode.Of("TLM-GC"),
+                ProductName = ProductName.Of("eGift Card"),
                 Description = "eGift Card",
                 UnitPrice = null,
             };
@@ -80,12 +80,12 @@ namespace Mandarin.Tests.Data
         {
             public static readonly Stockist KelbyTynan = new()
             {
-                StockistId = new StockistId(1),
-                StockistCode = new StockistCode("KT20"),
+                StockistId = StockistId.Of(1),
+                StockistCode = StockistCode.Of("KT20"),
                 StatusCode = StatusMode.Inactive,
                 Details = new StockistDetail
                 {
-                    StockistId = new StockistId(1),
+                    StockistId = StockistId.Of(1),
                     FirstName = "Kelby",
                     LastName = "Tynan",
                     DisplayName = "Kelby Tynan",
@@ -98,8 +98,8 @@ namespace Mandarin.Tests.Data
                 },
                 Commission = new Commission
                 {
-                    CommissionId = new CommissionId(1),
-                    StockistId = new StockistId(1),
+                    CommissionId = CommissionId.Of(1),
+                    StockistId = StockistId.Of(1),
                     StartDate = new DateTime(2019, 08, 23),
                     EndDate = new DateTime(2019, 11, 23),
                     Rate = 10,
@@ -109,12 +109,12 @@ namespace Mandarin.Tests.Data
 
             public static readonly Stockist OthilieMapples = new()
             {
-                StockistId = new StockistId(4),
-                StockistCode = new StockistCode("OM19"),
+                StockistId = StockistId.Of(4),
+                StockistCode = StockistCode.Of("OM19"),
                 StatusCode = StatusMode.ActiveHidden,
                 Details = new StockistDetail
                 {
-                    StockistId = new StockistId(4),
+                    StockistId = StockistId.Of(4),
                     FirstName = "Othilie",
                     LastName = "Mapples",
                     DisplayName = "Othilie Mapples",
@@ -127,8 +127,8 @@ namespace Mandarin.Tests.Data
                 },
                 Commission = new Commission
                 {
-                    CommissionId = new CommissionId(4),
-                    StockistId = new StockistId(4),
+                    CommissionId = CommissionId.Of(4),
+                    StockistId = StockistId.Of(4),
                     StartDate = new DateTime(2019, 01, 16),
                     EndDate = new DateTime(2019, 04, 16),
                     Rate = 40,
@@ -138,7 +138,7 @@ namespace Mandarin.Tests.Data
 
             public static readonly Stockist ArlueneWoodes = new()
             {
-                StockistCode = new StockistCode("AW20"),
+                StockistCode = StockistCode.Of("AW20"),
                 StatusCode = StatusMode.Active,
                 Details = new StockistDetail
                 {
@@ -162,7 +162,7 @@ namespace Mandarin.Tests.Data
 
             public static readonly Stockist TheLittleMandarin = new()
             {
-                StockistCode = new StockistCode("TLM"),
+                StockistCode = StockistCode.Of("TLM"),
                 StatusCode = StatusMode.Active,
                 Details = new StockistDetail
                 {


### PR DESCRIPTION
Was caused by using `new ProductId(value)` on a value that is not null checked, and without NRT enabled, this doesn't get flagged as a potential null problem.

Will need to enable NRT at a later point...