### PR TITLE
BASHI-135: Upgrade Npgsql to 6.0.2

### DIFF
--- a/src/Mandarin.Database/Mandarin.Database.csproj
+++ b/src/Mandarin.Database/Mandarin.Database.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="dbup-postgresql" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Npgsql" Version="5.0.7" />
+    <PackageReference Include="Npgsql" Version="6.0.2" />
     <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>
 

--- a/src/Mandarin.Database/Migrations/012-UpdateTimestampToWithTimeZone.sql
+++ b/src/Mandarin.Database/Migrations/012-UpdateTimestampToWithTimeZone.sql
@@ -1,0 +1,90 @@
+﻿-- BASHI-135: Upgrade Npgsql to 6.0.0
+SET TimeZone='UTC';
+
+ALTER TABLE billing.commission ALTER COLUMN inserted_at TYPE timestamp WITH TIME ZONE;
+ALTER TABLE billing.external_transaction ALTER COLUMN updated_at TYPE timestamp WITH TIME ZONE;
+ALTER TABLE billing.external_transaction ALTER COLUMN created_at TYPE timestamp WITH TIME ZONE;
+ALTER TABLE billing.transaction ALTER COLUMN timestamp TYPE timestamp WITH TIME ZONE;
+ALTER TABLE inventory.frame_price ALTER COLUMN created_at TYPE timestamp WITH TIME ZONE;
+ALTER TABLE inventory.frame_price ALTER COLUMN active_until TYPE timestamp WITH TIME ZONE;
+ALTER TABLE inventory.product ALTER COLUMN last_updated TYPE timestamp WITH TIME ZONE;
+
+DROP PROCEDURE inventory.sp_frame_price_upsert(TEXT, NUMERIC, TIMESTAMP);
+DROP PROCEDURE inventory.sp_product_upsert(VARCHAR, VARCHAR, VARCHAR, VARCHAR, NUMERIC, TIMESTAMP);
+DROP PROCEDURE billing.sp_transaction_upsert(VARCHAR, NUMERIC, TIMESTAMP, billing.tvp_subtransaction[]);
+
+CREATE OR REPLACE PROCEDURE inventory.sp_frame_price_upsert(
+    _product_code TEXT,
+    _amount NUMERIC,
+    _created_at TIMESTAMP WITH TIME ZONE)
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+BEGIN
+    UPDATE inventory.frame_price
+    SET active_until = $3
+    WHERE product_code = $1
+      AND active_until IS NULL;
+
+    INSERT INTO inventory.frame_price (product_code, amount, created_at)
+    VALUES ($1, $2, $3);
+END
+$$;
+
+CREATE OR REPLACE PROCEDURE inventory.sp_product_upsert(
+    _product_id     VARCHAR(32),
+    _product_code   VARCHAR(12),
+    _product_name   VARCHAR(100),
+    _description    VARCHAR(1000),
+    _unit_price     NUMERIC(6, 2),
+    _last_updated   TIMESTAMP(3) WITH TIME ZONE)
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE _stockist_id INT;
+BEGIN
+    SELECT stockist_id INTO _stockist_id
+    FROM inventory.stockist
+    WHERE stockist_code = left($2, strpos($2, '-') - 1);
+
+    INSERT INTO inventory.product (product_id, stockist_id, product_code, product_name, description, unit_price, last_updated)
+    VALUES ($1, _stockist_id, $2, $3, $4, $5, $6)
+    ON CONFLICT (product_id) DO UPDATE SET (stockist_id, product_code, product_name, description, unit_price, last_updated) = (_stockist_id, $2, $3, $4, $5, $6);
+END
+$$;
+
+CREATE OR REPLACE PROCEDURE billing.sp_transaction_upsert(
+    _external_transaction_id VARCHAR(32),
+    _total_amount NUMERIC(6, 2),
+    _timestamp TIMESTAMP(3) WITH TIME ZONE,
+    _subtransactions billing.TVP_SUBTRANSACTION[])
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    _transaction_id INT;
+    _commission_rate INT;
+    _subtransaction billing.TVP_SUBTRANSACTION;
+BEGIN
+    INSERT INTO billing.transaction (external_transaction_id, total_amount, timestamp)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (external_transaction_id) DO UPDATE SET (total_amount, timestamp) = ($2, $3)
+    RETURNING transaction_id INTO _transaction_id;
+
+    DELETE FROM billing.subtransaction WHERE transaction_id = _transaction_id;
+
+    FOREACH _subtransaction IN ARRAY $4
+        LOOP
+            SELECT c.rate INTO _commission_rate
+            FROM inventory.product p
+                     INNER JOIN inventory.stockist s ON s.stockist_id = p.stockist_id
+                     INNER JOIN billing.commission c ON c.stockist_id = s.stockist_id
+            WHERE p.product_id = _subtransaction.product_id
+            ORDER BY c.inserted_at DESC LIMIT 1;
+
+            INSERT INTO billing.subtransaction (transaction_id, product_id, quantity, unit_price, commission_rate)
+            SELECT _transaction_id, _subtransaction.product_id, _subtransaction.quantity, _subtransaction.unit_price, _commission_rate;
+        END LOOP;
+END
+$$;

--- a/src/Mandarin/Mandarin.csproj
+++ b/src/Mandarin/Mandarin.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.40.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.27" />
-    <PackageReference Include="Hangfire.PostgreSql" Version="1.8.6" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.9.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.0" />

--- a/tests/Mandarin.Tests/Helpers/Database/MandarinDbContextTestDataExtensions.cs
+++ b/tests/Mandarin.Tests/Helpers/Database/MandarinDbContextTestDataExtensions.cs
@@ -19,20 +19,20 @@ namespace Mandarin.Tests.Helpers.Database
             using var connection = mandarinDbContext.GetConnection();
             connection.Open();
             await connection.ExecuteAsync(@"
-                DROP PROCEDURE IF EXISTS inventory.sp_frame_price_upsert(TEXT, NUMERIC, TIMESTAMP);
-                DROP PROCEDURE IF EXISTS inventory.sp_product_upsert(VARCHAR, VARCHAR, VARCHAR, VARCHAR, NUMERIC, TIMESTAMP);
-                DROP PROCEDURE IF EXISTS billing.sp_transaction_upsert(VARCHAR, NUMERIC, TIMESTAMP, billing.tvp_subtransaction[]);
+                DROP PROCEDURE inventory.sp_frame_price_upsert(TEXT, NUMERIC, TIMESTAMP WITH TIME ZONE);
+                DROP PROCEDURE inventory.sp_product_upsert(VARCHAR, VARCHAR, VARCHAR, VARCHAR, NUMERIC, TIMESTAMP WITH TIME ZONE);
+                DROP PROCEDURE billing.sp_transaction_upsert(VARCHAR, NUMERIC, TIMESTAMP WITH TIME ZONE, billing.tvp_subtransaction[]);
 
-                DROP TYPE IF EXISTS billing.tvp_subtransaction;
+                DROP TYPE billing.tvp_subtransaction;
 
-                DROP TABLE IF EXISTS billing.commission;
-                DROP TABLE IF EXISTS billing.subtransaction;
-                DROP TABLE IF EXISTS billing.transaction;
-                DROP TABLE IF EXISTS billing.external_transaction;
-                DROP TABLE IF EXISTS inventory.frame_price;
-                DROP TABLE IF EXISTS inventory.product;
-                DROP TABLE IF EXISTS inventory.stockist_detail;
-                DROP TABLE IF EXISTS inventory.stockist;
+                DROP TABLE billing.commission;
+                DROP TABLE billing.subtransaction;
+                DROP TABLE billing.transaction;
+                DROP TABLE billing.external_transaction;
+                DROP TABLE inventory.frame_price;
+                DROP TABLE inventory.product;
+                DROP TABLE inventory.stockist_detail;
+                DROP TABLE inventory.stockist;
                 TRUNCATE TABLE public.schemaversions");
         }
     }


### PR DESCRIPTION
Dependency upgrade gives potential to push SQL to APM via OpenTelemetry, but still a bit clunky with Elastic APM at the moment...

Breaking changes in upgrade as `Instant` is now treated as a `TIMESTAMP WITH TIME ZONE` instead of `TIMESTAMP WITHOUT TIME ZONE`!